### PR TITLE
feat: make settings editable

### DIFF
--- a/js/game.js
+++ b/js/game.js
@@ -290,7 +290,7 @@ function drawFrame() {
   if (!showSettings) game.sprite.draw(ctx, cameraY);
 
   drawHUD();
-  drawSettings(ctx, budgetData);
+  drawSettings(resetGame);
 }
 
 // kick off


### PR DESCRIPTION
## Summary
- add editable settings panel overlay with JSON budget textarea
- restart game with custom settings via play button

## Testing
- `node --check js/settings.js`
- `node --check js/game.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c65213e1f0832d8c4ecf4ffee01dc9