### PR TITLE
Add joystick-style run controls and directional stretch

### DIFF
--- a/js/input.js
+++ b/js/input.js
@@ -1,5 +1,16 @@
-import { MIN_SWIPE_DISTANCE } from './constants.js';
-import { canvas, canvasWidth } from './globals.js';
+import {
+  MIN_SWIPE_DISTANCE,
+  MIN_SWIPE_TIME,
+  VELOCITY_SAMPLE_TIME,
+  MIN_PLATFORM_SPEED,
+  MAX_PLATFORM_SPEED,
+  MAX_PLATFORMS,
+  PLATFORM_MIN_WIDTH,
+  PLATFORM_MAX_WIDTH
+} from './constants.js';
+import { canvas, canvasWidth, cameraY } from './globals.js';
+import { Platform } from './platforms.js';
+import { clamp } from './utils.js';
 import { showSettings, toggleSettings, hideSettings } from './settings.js';
 
 export class InputHandler {
@@ -9,14 +20,27 @@ export class InputHandler {
 
     this.touchStart = null;
     this.lastTouch = null;
+    this.touchSamples = [];
+    this.touchSwipe = false;
+    this.touchMode = null; // 'move' or 'platform'
 
     this.mouseStart = null;
     this.lastMouse = null;
+    this.mouseSamples = [];
+    this.mouseSwipe = false;
     this.isMouseDown = false;
+    this.mouseMode = null;
 
     this.arrowState = { ArrowLeft: false, ArrowRight: false, ArrowUp: false, ArrowDown: false };
     this.arrowCharging = false;
     this.spaceCharging = false;
+
+    this.lastArrowTime = 0;
+    this.arrowCooldownMs = 140;
+
+    this.trackpadGestureActive = false;
+    this.trackpadStartX = 0;
+    this.trackpadStartTime = 0;
 
     this.bind();
   }
@@ -53,12 +77,19 @@ export class InputHandler {
         return;
       }
 
-      if (!this.game.sprite.onGround) return;
-
       e.preventDefault();
-      this.touchStart = { x, y };
-      this.lastTouch = { x, y };
-      this._startCharge();
+      if (this.game.sprite.onGround) {
+        this.touchMode = 'move';
+        this.touchStart = { x, y };
+        this.lastTouch = { x, y };
+        this._startCharge();
+      } else {
+        this.touchMode = 'platform';
+        const time = Date.now();
+        this.touchStart = { x, y, time };
+        this.touchSamples = [{ ...this.touchStart }];
+        this.touchSwipe = false;
+      }
     }, { passive: false });
 
     canvas.addEventListener('touchmove', (e) => {
@@ -66,7 +97,21 @@ export class InputHandler {
       e.preventDefault();
       const t = e.touches[0];
       const r = canvas.getBoundingClientRect();
-      this.lastTouch = { x: t.clientX - r.left, y: t.clientY - r.top };
+      const x = t.clientX - r.left;
+      const y = t.clientY - r.top;
+      if (this.touchMode === 'move') {
+        this.lastTouch = { x, y };
+      } else {
+        const s = { x, y, time: Date.now() };
+        this.touchSamples.push(s);
+        const cutoff = s.time - VELOCITY_SAMPLE_TIME;
+        this.touchSamples = this.touchSamples.filter(q => q.time >= cutoff);
+        const dx = s.x - this.touchStart.x;
+        const dt = s.time - this.touchStart.time;
+        if (!this.touchSwipe && Math.abs(dx) >= MIN_SWIPE_DISTANCE && dt >= MIN_SWIPE_TIME) {
+          this.touchSwipe = true;
+        }
+      }
       if (!this.game.sprite.onGround && this.game.sprite.vy > 0 && !this.game.sprite.gliding && this.game.energyBar.canUse()) {
         this.game.sprite.startGliding();
       }
@@ -75,11 +120,24 @@ export class InputHandler {
     canvas.addEventListener('touchend', (e) => {
       if (!this.touchStart || showSettings) return;
       e.preventDefault();
-      const end = this.lastTouch || this.touchStart;
-      const dx = end.x - this.touchStart.x;
-      const dy = end.y - this.touchStart.y;
-      this._finishCharge(dx, dy);
-      this.touchStart = null; this.lastTouch = null;
+      if (this.touchMode === 'move') {
+        const end = this.lastTouch || this.touchStart;
+        const dx = end.x - this.touchStart.x;
+        const dy = end.y - this.touchStart.y;
+        this._finishCharge(dx, dy);
+        this.touchStart = null; this.lastTouch = null;
+      } else {
+        const endTime = Date.now();
+        const last = this.touchSamples[this.touchSamples.length - 1] || this.touchStart;
+        const dx = last.x - this.touchStart.x;
+        const total = Math.max(1, endTime - this.touchStart.time);
+        if (this.touchSwipe) this.createPlatformFromGesture(dx, total, last.y);
+        else this.game.sprite.releaseJump();
+        this.game.sprite.stopGliding();
+        this.touchStart = null;
+        this.touchSamples = [];
+        this.touchSwipe = false;
+      }
     }, { passive: false });
 
     // Mouse
@@ -93,17 +151,39 @@ export class InputHandler {
         return;
       }
       if (showSettings) { hideSettings(); this.ensureReset(); return; }
-      if (!this.game.sprite.onGround) return;
-      this.mouseStart = { x, y };
-      this.lastMouse = { x, y };
       this.isMouseDown = true;
-      this._startCharge();
+      if (this.game.sprite.onGround) {
+        this.mouseMode = 'move';
+        this.mouseStart = { x, y };
+        this.lastMouse = { x, y };
+        this._startCharge();
+      } else {
+        this.mouseMode = 'platform';
+        const time = Date.now();
+        this.mouseStart = { x, y, time };
+        this.mouseSamples = [{ ...this.mouseStart }];
+        this.mouseSwipe = false;
+      }
     });
 
     canvas.addEventListener('mousemove', (e) => {
       if (!this.isMouseDown || showSettings) return;
       const r = canvas.getBoundingClientRect();
-      this.lastMouse = { x: e.clientX - r.left, y: e.clientY - r.top };
+      const x = e.clientX - r.left;
+      const y = e.clientY - r.top;
+      if (this.mouseMode === 'move') {
+        this.lastMouse = { x, y };
+      } else {
+        const s = { x, y, time: Date.now() };
+        this.mouseSamples.push(s);
+        const cutoff = s.time - VELOCITY_SAMPLE_TIME;
+        this.mouseSamples = this.mouseSamples.filter(q => q.time >= cutoff);
+        const dx = s.x - this.mouseStart.x;
+        const dt = s.time - this.mouseStart.time;
+        if (!this.mouseSwipe && Math.abs(dx) >= MIN_SWIPE_DISTANCE && dt >= MIN_SWIPE_TIME) {
+          this.mouseSwipe = true;
+        }
+      }
       if (!this.game.sprite.onGround && this.game.sprite.vy > 0 && !this.game.sprite.gliding && this.game.energyBar.canUse()) {
         this.game.sprite.startGliding();
       }
@@ -111,12 +191,53 @@ export class InputHandler {
 
     canvas.addEventListener('mouseup', () => {
       if (!this.isMouseDown || showSettings) return;
-      const end = this.lastMouse || this.mouseStart;
-      const dx = end.x - this.mouseStart.x;
-      const dy = end.y - this.mouseStart.y;
-      this._finishCharge(dx, dy);
+      if (this.mouseMode === 'move') {
+        const end = this.lastMouse || this.mouseStart;
+        const dx = end.x - this.mouseStart.x;
+        const dy = end.y - this.mouseStart.y;
+        this._finishCharge(dx, dy);
+      } else {
+        const endTime = Date.now();
+        const last = this.mouseSamples[this.mouseSamples.length - 1] || this.mouseStart;
+        const dx = last.x - this.mouseStart.x;
+        const total = Math.max(1, endTime - this.mouseStart.time);
+        if (this.mouseSwipe) this.createPlatformFromGesture(dx, total, last.y);
+        else this.game.sprite.releaseJump();
+        this.game.sprite.stopGliding();
+        this.mouseSamples = [];
+        this.mouseSwipe = false;
+      }
       this.isMouseDown = false;
-      this.mouseStart = null; this.lastMouse = null;
+      this.mouseStart = null; this.lastMouse = null; this.mouseMode = null;
+    });
+
+    // Trackpad gesture
+    canvas.addEventListener('wheel', (e) => {
+      if (showSettings || this.game.sprite.onGround) return;
+      if (Math.abs(e.deltaX) > Math.abs(e.deltaY) && Math.abs(e.deltaX) > 10) {
+        e.preventDefault();
+        if (!this.trackpadGestureActive) {
+          this.trackpadGestureActive = true;
+          this.trackpadStartX = e.deltaX;
+          this.trackpadStartTime = Date.now();
+          return;
+        }
+        const currentTime = Date.now();
+        const totalDeltaX = e.deltaX - this.trackpadStartX;
+        const totalTime = currentTime - this.trackpadStartTime;
+        if (Math.abs(totalDeltaX) > 50 && totalTime > 100) {
+          const rect = canvas.getBoundingClientRect();
+          const mouseY = e.clientY - rect.top;
+          this.createPlatformFromGesture(totalDeltaX, totalTime, mouseY);
+          this.trackpadGestureActive = false;
+        }
+      } else {
+        this.trackpadGestureActive = false;
+      }
+    }, { passive: false });
+
+    canvas.addEventListener('mouseleave', () => {
+      this.trackpadGestureActive = false;
     });
 
     // Keyboard
@@ -127,13 +248,22 @@ export class InputHandler {
         this._startCharge();
       }
       if (['ArrowLeft','ArrowRight','ArrowUp','ArrowDown'].includes(e.code) && !showSettings) {
-        if (!this.game.sprite.onGround) return;
-        e.preventDefault();
-        if (!this.arrowCharging) {
-          this.arrowCharging = true;
-          this._startCharge();
+        if (this.game.sprite.onGround) {
+          e.preventDefault();
+          if (!this.arrowCharging) {
+            this.arrowCharging = true;
+            this._startCharge();
+          }
+          this.arrowState[e.code] = true;
+        } else if (e.code === 'ArrowLeft' || e.code === 'ArrowRight') {
+          e.preventDefault();
+          const now = Date.now();
+          if (now - this.lastArrowTime >= this.arrowCooldownMs) {
+            this.lastArrowTime = now;
+            const dir = e.code === 'ArrowRight' ? 1 : -1;
+            this.createPlatformFromKey(dir);
+          }
         }
-        this.arrowState[e.code] = true;
       }
     });
 
@@ -158,5 +288,40 @@ export class InputHandler {
         }
       }
     });
+  }
+
+  createPlatformFromGesture(dx, totalTimeMs, screenY) {
+    const activeMovers = this.game.platforms.filter(p => p.direction !== 0).length;
+    if (activeMovers >= MAX_PLATFORMS) return;
+
+    const dir = (dx >= 0) ? 1 : -1;
+    const speedRaw = Math.abs(dx) / (totalTimeMs / 1000);
+    const speed = clamp(speedRaw, MIN_PLATFORM_SPEED, MAX_PLATFORM_SPEED);
+
+    const w = clamp(
+      PLATFORM_MIN_WIDTH + (PLATFORM_MAX_WIDTH - PLATFORM_MIN_WIDTH) * (totalTimeMs / 700),
+      PLATFORM_MIN_WIDTH,
+      PLATFORM_MAX_WIDTH
+    );
+
+    const worldY = screenY + cameraY;
+    const x = (dir > 0) ? -w : canvasWidth;
+    const platform = new Platform(x, worldY, w, speed, dir);
+    this.game.platforms.push(platform);
+  }
+
+  createPlatformFromKey(dir) {
+    const activeMovers = this.game.platforms.filter(p => p.direction !== 0).length;
+    if (activeMovers >= MAX_PLATFORMS) return;
+
+    const w = (PLATFORM_MIN_WIDTH + PLATFORM_MAX_WIDTH) * 0.5;
+    const speed = (MIN_PLATFORM_SPEED + MAX_PLATFORM_SPEED) * 0.6;
+
+    const screenY = canvas.height * 0.5;
+    const worldY = screenY + cameraY;
+    const x = (canvasWidth * 0.5) - (w * 0.5);
+
+    const platform = new Platform(x, worldY, w, speed, dir);
+    this.game.platforms.push(platform);
   }
 }

--- a/js/input.js
+++ b/js/input.js
@@ -35,19 +35,27 @@ export class InputHandler {
   bind() {
     // Touch
     canvas.addEventListener('touchstart', (e) => {
-      e.preventDefault();
       const t = e.touches[0];
       const r = canvas.getBoundingClientRect();
       const x = t.clientX - r.left;
       const y = t.clientY - r.top;
 
       if (x > canvasWidth - 50 && y < 50) {
+        e.preventDefault();
         toggleSettings();
         if (!showSettings) this.ensureReset();
         return;
       }
-      if (showSettings) { hideSettings(); this.ensureReset(); return; }
+      if (showSettings) {
+        e.preventDefault();
+        hideSettings();
+        this.ensureReset();
+        return;
+      }
 
+      if (!this.game.sprite.onGround) return;
+
+      e.preventDefault();
       this.touchStart = { x, y };
       this.lastTouch = { x, y };
       this._startCharge();
@@ -85,6 +93,7 @@ export class InputHandler {
         return;
       }
       if (showSettings) { hideSettings(); this.ensureReset(); return; }
+      if (!this.game.sprite.onGround) return;
       this.mouseStart = { x, y };
       this.lastMouse = { x, y };
       this.isMouseDown = true;
@@ -118,6 +127,7 @@ export class InputHandler {
         this._startCharge();
       }
       if (['ArrowLeft','ArrowRight','ArrowUp','ArrowDown'].includes(e.code) && !showSettings) {
+        if (!this.game.sprite.onGround) return;
         e.preventDefault();
         if (!this.arrowCharging) {
           this.arrowCharging = true;

--- a/js/input.js
+++ b/js/input.js
@@ -1,284 +1,152 @@
-import {
-    MIN_SWIPE_DISTANCE, MIN_SWIPE_TIME, VELOCITY_SAMPLE_TIME,
-    MIN_PLATFORM_SPEED, MAX_PLATFORM_SPEED, MAX_PLATFORMS,
-    PLATFORM_MIN_WIDTH, PLATFORM_MAX_WIDTH
-  } from './constants.js';
-  import { canvas, canvasWidth, cameraY } from './globals.js';
-  import { Platform } from './platforms.js';
-  import { clamp } from './utils.js';
-  import { showSettings, toggleSettings, hideSettings } from './settings.js';
-  
-  export class InputHandler {
-    constructor(game, ensureReset) {
-      this.game = game;
-      this.ensureReset = ensureReset;
-  
-      this.touchStart = null;
-      this.touchSamples = [];
-      this.touchSwipe = false;
-  
-      this.mouseStart = null;
-      this.mouseSamples = [];
-      this.isMouseDragging = false;
-      this.mouseSwipe = false;
-  
-      // Keyboard jump charge (space)
-      this.keyboardCharging = false;
-      this.keyboardChargeStart = 0;
-  
-      // Trackpad gesture support
-      this.trackpadGestureActive = false;
-      this.trackpadStartX = 0;
-      this.trackpadStartTime = 0;
-  
-      // Arrow-key spawn debounce
-      this.lastArrowTime = 0;
-      this.arrowCooldownMs = 140; // light debounce to avoid spam
-  
-      this.bind();
-    }
-  
-    bind() {
-      // ----------------------------
-      // Touch
-      // ----------------------------
-      canvas.addEventListener('touchstart', (e) => {
+import { MIN_SWIPE_DISTANCE } from './constants.js';
+import { canvas, canvasWidth } from './globals.js';
+import { showSettings, toggleSettings, hideSettings } from './settings.js';
+
+export class InputHandler {
+  constructor(game, ensureReset) {
+    this.game = game;
+    this.ensureReset = ensureReset;
+
+    this.touchStart = null;
+    this.lastTouch = null;
+
+    this.mouseStart = null;
+    this.lastMouse = null;
+    this.isMouseDown = false;
+
+    this.arrowState = { ArrowLeft: false, ArrowRight: false, ArrowUp: false, ArrowDown: false };
+    this.arrowCharging = false;
+    this.spaceCharging = false;
+
+    this.bind();
+  }
+
+  _startCharge() {
+    this.game.sprite.startCharging();
+    if (!this.game.sprite.onGround && this.game.sprite.vy > 0) this.game.sprite.startGliding();
+  }
+
+  _finishCharge(dx, dy) {
+    if (Math.hypot(dx, dy) <= MIN_SWIPE_DISTANCE) this.game.sprite.releaseJump();
+    else this.game.sprite.releaseMove(dx, dy);
+    this.game.sprite.stopGliding();
+  }
+
+  bind() {
+    // Touch
+    canvas.addEventListener('touchstart', (e) => {
+      e.preventDefault();
+      const t = e.touches[0];
+      const r = canvas.getBoundingClientRect();
+      const x = t.clientX - r.left;
+      const y = t.clientY - r.top;
+
+      if (x > canvasWidth - 50 && y < 50) {
+        toggleSettings();
+        if (!showSettings) this.ensureReset();
+        return;
+      }
+      if (showSettings) { hideSettings(); this.ensureReset(); return; }
+
+      this.touchStart = { x, y };
+      this.lastTouch = { x, y };
+      this._startCharge();
+    }, { passive: false });
+
+    canvas.addEventListener('touchmove', (e) => {
+      e.preventDefault();
+      if (!this.touchStart || showSettings) return;
+      const t = e.touches[0];
+      const r = canvas.getBoundingClientRect();
+      this.lastTouch = { x: t.clientX - r.left, y: t.clientY - r.top };
+      if (!this.game.sprite.onGround && this.game.sprite.vy > 0 && !this.game.sprite.gliding && this.game.energyBar.canUse()) {
+        this.game.sprite.startGliding();
+      }
+    }, { passive: false });
+
+    canvas.addEventListener('touchend', (e) => {
+      e.preventDefault();
+      if (!this.touchStart || showSettings) return;
+      const end = this.lastTouch || this.touchStart;
+      const dx = end.x - this.touchStart.x;
+      const dy = end.y - this.touchStart.y;
+      this._finishCharge(dx, dy);
+      this.touchStart = null; this.lastTouch = null;
+    }, { passive: false });
+
+    // Mouse
+    canvas.addEventListener('mousedown', (e) => {
+      const r = canvas.getBoundingClientRect();
+      const x = e.clientX - r.left;
+      const y = e.clientY - r.top;
+      if (x > canvasWidth - 50 && y < 50) {
+        toggleSettings();
+        if (!showSettings) this.ensureReset();
+        return;
+      }
+      if (showSettings) { hideSettings(); this.ensureReset(); return; }
+      this.mouseStart = { x, y };
+      this.lastMouse = { x, y };
+      this.isMouseDown = true;
+      this._startCharge();
+    });
+
+    canvas.addEventListener('mousemove', (e) => {
+      if (!this.isMouseDown || showSettings) return;
+      const r = canvas.getBoundingClientRect();
+      this.lastMouse = { x: e.clientX - r.left, y: e.clientY - r.top };
+      if (!this.game.sprite.onGround && this.game.sprite.vy > 0 && !this.game.sprite.gliding && this.game.energyBar.canUse()) {
+        this.game.sprite.startGliding();
+      }
+    });
+
+    canvas.addEventListener('mouseup', () => {
+      if (!this.isMouseDown || showSettings) return;
+      const end = this.lastMouse || this.mouseStart;
+      const dx = end.x - this.mouseStart.x;
+      const dy = end.y - this.mouseStart.y;
+      this._finishCharge(dx, dy);
+      this.isMouseDown = false;
+      this.mouseStart = null; this.lastMouse = null;
+    });
+
+    // Keyboard
+    document.addEventListener('keydown', (e) => {
+      if (e.code === 'Space' && !showSettings && !this.spaceCharging) {
         e.preventDefault();
-        const touch = e.touches[0];
-        const rect = canvas.getBoundingClientRect();
-        const x = touch.clientX - rect.left;
-        const y = touch.clientY - rect.top;
-  
-        // toggle settings
-        if (x > canvasWidth - 50 && y < 50) {
-          toggleSettings();
-          if (!showSettings) this.ensureReset();
-          return;
-        }
-        if (showSettings) { hideSettings(); this.ensureReset(); return; }
-  
-        this.touchStart = { x, y, time: Date.now() };
-        this.touchSamples = [{ ...this.touchStart }];
-        this.touchSwipe = false;
-  
-        this.game.sprite.startCharging();
-        if (!this.game.sprite.onGround && this.game.sprite.vy > 0) this.game.sprite.startGliding();
-      }, { passive: false });
-  
-      canvas.addEventListener('touchmove', (e) => {
+        this.spaceCharging = true;
+        this._startCharge();
+      }
+      if (['ArrowLeft','ArrowRight','ArrowUp','ArrowDown'].includes(e.code) && !showSettings) {
         e.preventDefault();
-        if (!this.touchStart || showSettings) return;
-        const t = e.touches[0];
-        const r = canvas.getBoundingClientRect();
-        const s = { x: t.clientX - r.left, y: t.clientY - r.top, time: Date.now() };
-        this.touchSamples.push(s);
-        const cutoff = s.time - VELOCITY_SAMPLE_TIME;
-        this.touchSamples = this.touchSamples.filter(q => q.time >= cutoff);
-  
-        const dx = s.x - this.touchStart.x;
-        const dt = s.time - this.touchStart.time;
-        if (!this.touchSwipe && Math.abs(dx) >= MIN_SWIPE_DISTANCE && dt >= MIN_SWIPE_TIME) {
-          this.touchSwipe = true;
-          this.game.sprite.charging = false;
+        if (!this.arrowCharging) {
+          this.arrowCharging = true;
+          this._startCharge();
         }
-        if (!this.game.sprite.onGround && this.game.sprite.vy > 0 && !this.game.sprite.gliding && this.game.energyBar.canUse()) {
-          this.game.sprite.startGliding();
-        }
-      }, { passive: false });
-  
-      canvas.addEventListener('touchend', (e) => {
+        this.arrowState[e.code] = true;
+      }
+    });
+
+    document.addEventListener('keyup', (e) => {
+      if (e.code === 'Space' && this.spaceCharging) {
         e.preventDefault();
-        if (!this.touchStart || showSettings) return;
-        const endTime = Date.now();
-        const last = this.touchSamples[this.touchSamples.length - 1] || this.touchStart;
-        const dx = last.x - this.touchStart.x;
-        const total = Math.max(1, endTime - this.touchStart.time);
-  
-        if (this.touchSwipe) this.createPlatformFromGesture(dx, total, last.y);
-        else this.game.sprite.releaseJump();
-  
-        this.game.sprite.stopGliding();
-        this.touchStart = null; this.touchSamples = []; this.touchSwipe = false;
-      }, { passive: false });
-  
-      // ----------------------------
-      // Mouse
-      // ----------------------------
-      canvas.addEventListener('mousedown', (e) => {
-        const r = canvas.getBoundingClientRect();
-        const x = e.clientX - r.left;
-        const y = e.clientY - r.top;
-  
-        if (x > canvasWidth - 50 && y < 50) {
-          toggleSettings();
-          if (!showSettings) this.ensureReset();
-          return;
-        }
-        if (showSettings) { hideSettings(); this.ensureReset(); return; }
-  
-        this.mouseStart = { x, y, time: Date.now() };
-        this.mouseSamples = [{ ...this.mouseStart }];
-        this.isMouseDragging = true;
-        this.mouseSwipe = false;
-  
-        this.game.sprite.startCharging();
-        if (!this.game.sprite.onGround && this.game.sprite.vy > 0) this.game.sprite.startGliding();
-      });
-  
-      canvas.addEventListener('mousemove', (e) => {
-        if (!this.isMouseDragging || showSettings) return;
-        const r = canvas.getBoundingClientRect();
-        const s = { x: e.clientX - r.left, y: e.clientY - r.top, time: Date.now() };
-        this.mouseSamples.push(s);
-        const cutoff = s.time - VELOCITY_SAMPLE_TIME;
-        this.mouseSamples = this.mouseSamples.filter(q => q.time >= cutoff);
-  
-        const dx = s.x - this.mouseStart.x;
-        const dt = s.time - this.mouseStart.time;
-        if (!this.mouseSwipe && Math.abs(dx) >= MIN_SWIPE_DISTANCE && dt >= MIN_SWIPE_TIME) {
-          this.mouseSwipe = true;
-          this.game.sprite.charging = false;
-        }
-        if (!this.game.sprite.onGround && this.game.sprite.vy > 0 && !this.game.sprite.gliding && this.game.energyBar.canUse()) {
-          this.game.sprite.startGliding();
-        }
-      });
-  
-      canvas.addEventListener('mouseup', () => {
-        if (!this.mouseStart || showSettings) return;
-        const endTime = Date.now();
-        const last = this.mouseSamples[this.mouseSamples.length - 1] || this.mouseStart;
-        const dx = last.x - this.mouseStart.x;
-        const total = Math.max(1, endTime - this.mouseStart.time);
-  
-        if (this.mouseSwipe) this.createPlatformFromGesture(dx, total, last.y);
-        else this.game.sprite.releaseJump();
-  
-        this.game.sprite.stopGliding();
-        this.isMouseDragging = false;
-        this.mouseStart = null;
-        this.mouseSamples = [];
-        this.mouseSwipe = false;
-      });
-  
-      // ----------------------------
-      // Trackpad (two-finger horizontal swipe)
-      // ----------------------------
-      canvas.addEventListener('wheel', (e) => {
-        if (showSettings) return;
-  
-        if (Math.abs(e.deltaX) > Math.abs(e.deltaY) && Math.abs(e.deltaX) > 10) {
-          e.preventDefault();
-  
-          if (!this.trackpadGestureActive) {
-            this.trackpadGestureActive = true;
-            this.trackpadStartX = e.deltaX;
-            this.trackpadStartTime = Date.now();
-            return;
-          }
-  
-          const currentTime = Date.now();
-          const totalDeltaX = e.deltaX - this.trackpadStartX;
-          const totalTime = currentTime - this.trackpadStartTime;
-  
-          if (Math.abs(totalDeltaX) > 50 && totalTime > 100) {
-            const rect = canvas.getBoundingClientRect();
-            const mouseY = e.clientY - rect.top;
-            this.createPlatformFromGesture(totalDeltaX, totalTime, mouseY);
-            this.trackpadGestureActive = false;
-          }
-        } else {
-          this.trackpadGestureActive = false;
-        }
-      }, { passive: false });
-  
-      canvas.addEventListener('mouseleave', () => {
-        this.trackpadGestureActive = false;
-      });
-  
-      // ----------------------------
-      // Keyboard: Jump (Space)
-      // ----------------------------
-      document.addEventListener('keydown', (e) => {
-        if (e.code === 'Space' && !showSettings && !this.keyboardCharging) {
-          e.preventDefault();
-          this.keyboardCharging = true;
-          this.keyboardChargeStart = Date.now();
-          this.game.sprite.startCharging();
-          if (!this.game.sprite.onGround && this.game.sprite.vy > 0) this.game.sprite.startGliding();
-        }
-      });
-  
-      document.addEventListener('keyup', (e) => {
-        if (e.code === 'Space' && !showSettings && this.keyboardCharging) {
-          e.preventDefault();
-          this.keyboardCharging = false;
-          this.game.sprite.releaseJump();
+        this.spaceCharging = false;
+        this._finishCharge(0, -1);
+      }
+      if (['ArrowLeft','ArrowRight','ArrowUp','ArrowDown'].includes(e.code) && this.arrowCharging) {
+        e.preventDefault();
+        const dir = {
+          x: (this.arrowState.ArrowRight ? 1 : 0) - (this.arrowState.ArrowLeft ? 1 : 0),
+          y: (this.arrowState.ArrowDown ? 1 : 0) - (this.arrowState.ArrowUp ? 1 : 0)
+        };
+        this.arrowState[e.code] = false;
+        if (!this.arrowState.ArrowLeft && !this.arrowState.ArrowRight && !this.arrowState.ArrowUp && !this.arrowState.ArrowDown) {
+          this.arrowCharging = false;
+          if (dir.x === 0 && dir.y === 0) this.game.sprite.releaseJump();
+          else this.game.sprite.releaseMove(dir.x, dir.y);
           this.game.sprite.stopGliding();
         }
-      });
-  
-      // Prevent space from scrolling the page
-      document.addEventListener('keydown', (e) => {
-        if (e.code === 'Space') e.preventDefault();
-  
-        // ----------------------------
-        // Keyboard: Left/Right arrows -> spawn moving platform mid-screen
-        // ----------------------------
-        if ((e.code === 'ArrowLeft' || e.code === 'ArrowRight') && !showSettings) {
-          e.preventDefault();
-          const now = Date.now();
-          if (now - this.lastArrowTime < this.arrowCooldownMs) return;
-          this.lastArrowTime = now;
-  
-          const dir = (e.code === 'ArrowRight') ? 1 : -1;
-          this.createPlatformFromKey(dir);
-        }
-      });
-    }
-  
-    /**
-     * Creates a platform from a left/right swipe or trackpad gesture.
-     * Spawns from the corresponding canvas edge and moves inward.
-     */
-    createPlatformFromGesture(dx, totalTimeMs, screenY) {
-      const activeMovers = this.game.platforms.filter(p => p.direction !== 0).length;
-      if (activeMovers >= MAX_PLATFORMS) return;
-  
-      const dir = (dx >= 0) ? 1 : -1;
-      const speedRaw = Math.abs(dx) / (totalTimeMs / 1000);
-      const speed = clamp(speedRaw, MIN_PLATFORM_SPEED, MAX_PLATFORM_SPEED);
-  
-      const w = clamp(
-        PLATFORM_MIN_WIDTH + (PLATFORM_MAX_WIDTH - PLATFORM_MIN_WIDTH) * (totalTimeMs / 700),
-        PLATFORM_MIN_WIDTH, PLATFORM_MAX_WIDTH
-      );
-  
-      const worldY = screenY + cameraY;
-      const x = (dir > 0) ? -w : canvasWidth;
-      const platform = new Platform(x, worldY, w, speed, dir);
-      this.game.platforms.push(platform);
-    }
-  
-    /**
-     * Creates a platform from keyboard arrow input.
-     * Spawns horizontally centered (mid-screen), at mid-screen Y, moving left/right.
-     * Uses a comfortable default width/speed so it feels snappy without a "charge".
-     */
-    createPlatformFromKey(dir) {
-      const activeMovers = this.game.platforms.filter(p => p.direction !== 0).length;
-      if (activeMovers >= MAX_PLATFORMS) return;
-  
-      // Reasonable defaults for keyboard: mid width & mid speed
-      const w = (PLATFORM_MIN_WIDTH + PLATFORM_MAX_WIDTH) * 0.5;
-      const speed = (MIN_PLATFORM_SPEED + MAX_PLATFORM_SPEED) * 0.6; // a bit brisk
-  
-      // Mid-screen spawn
-      const screenY = canvas.height * 0.5;
-      const worldY = screenY + cameraY;
-      const x = (canvasWidth * 0.5) - (w * 0.5);
-  
-      const platform = new Platform(x, worldY, w, speed, dir);
-      this.game.platforms.push(platform);
-    }
-  }  
+      }
+    });
+  }
+}

--- a/js/input.js
+++ b/js/input.js
@@ -62,8 +62,8 @@ export class InputHandler {
     }, { passive: false });
 
     canvas.addEventListener('touchmove', (e) => {
-      e.preventDefault();
       if (!this.touchStart || showSettings) return;
+      e.preventDefault();
       const t = e.touches[0];
       const r = canvas.getBoundingClientRect();
       this.lastTouch = { x: t.clientX - r.left, y: t.clientY - r.top };
@@ -73,8 +73,8 @@ export class InputHandler {
     }, { passive: false });
 
     canvas.addEventListener('touchend', (e) => {
-      e.preventDefault();
       if (!this.touchStart || showSettings) return;
+      e.preventDefault();
       const end = this.lastTouch || this.touchStart;
       const dx = end.x - this.touchStart.x;
       const dy = end.y - this.touchStart.y;


### PR DESCRIPTION
## Summary
- Add input system for joystick-like control via drag gestures, mouse, or arrow keys that launches the sprite opposite the drag direction
- Implement releaseMove and velocity-based scaling so sprite stretches along movement direction
- Preserve vertical jump when no drag and support spacebar jump

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c658547ce4832d9b7ffcdd6ec23fba