### PR TITLE
Limit canvas width for mobile screens

### DIFF
--- a/js/constants.js
+++ b/js/constants.js
@@ -1,4 +1,7 @@
 // Tunables & constants
+// Limit the game's canvas width so it fits most mobile screens
+export const CANVAS_MAX_WIDTH = 480;
+
 export const GRAVITY = 2000;
 export const GLIDE_GRAVITY_FACTOR = 0.16;
 export const GROUND_FRICTION = 1200;

--- a/js/globals.js
+++ b/js/globals.js
@@ -1,4 +1,4 @@
-import { GRID_SIZE } from './constants.js';
+import { GRID_SIZE, CANVAS_MAX_WIDTH } from './constants.js';
 
 export const canvas = document.getElementById('gameCanvas');
 export const ctx = canvas.getContext('2d', { alpha: true });
@@ -16,7 +16,9 @@ export function setCameraY(v) { cameraY = v; }
 export function addMaxHeight(v) { maxHeight = Math.max(maxHeight, v); }
 
 export function resize() {
-  canvas.width = window.innerWidth;
+  const desiredWidth = Math.min(window.innerWidth, CANVAS_MAX_WIDTH);
+  canvas.width = desiredWidth;
+  canvas.style.width = `${desiredWidth}px`;
   canvas.height = window.innerHeight;
   canvasWidth = canvas.width;
   canvasHeight = canvas.height;

--- a/styles.css
+++ b/styles.css
@@ -16,6 +16,8 @@ html, body {
 canvas {
   display: block;
   width: 100%;
+  max-width: 480px;
+  margin: 0 auto;
   height: auto;
   background: var(--bg);
   border: 4px solid var(--ink);


### PR DESCRIPTION
## Summary
- constrain game canvas to 480px max width to better match mobile displays
- resize logic now caps width and sets explicit CSS sizing
- style updates center the canvas and keep height proportional

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c6617b2220832d8fc61cfc0fd7f4b0