### PR TITLE
Add joystick-based platform spawning toggle

### DIFF
--- a/js/game.js
+++ b/js/game.js
@@ -288,6 +288,7 @@ function drawFrame() {
   for (const c of collectibles) c.draw(ctx, cameraY, canvasHeight);
 
   if (!showSettings) game.sprite.draw(ctx, cameraY);
+  if (game.input && !showSettings) game.input.draw(ctx);
 
   drawHUD();
   drawSettings(resetGame);

--- a/js/input.js
+++ b/js/input.js
@@ -1,374 +1,385 @@
 import {
-    MIN_SWIPE_DISTANCE, MIN_SWIPE_TIME, VELOCITY_SAMPLE_TIME,
-    MIN_PLATFORM_SPEED, MAX_PLATFORM_SPEED, MAX_PLATFORMS,
-    PLATFORM_MIN_WIDTH, PLATFORM_MAX_WIDTH
-  } from './constants.js';
-  import { canvas, canvasWidth, cameraY } from './globals.js';
-  import { Platform } from './platforms.js';
-  import { clamp } from './utils.js';
-  import { showSettings, toggleSettings, hideSettings } from './settings.js';
-  
-  export class InputHandler {
-    constructor(game, ensureReset) {
-      this.game = game;
-      this.ensureReset = ensureReset;
-  
+  MIN_SWIPE_DISTANCE,
+  MIN_SWIPE_TIME,
+  VELOCITY_SAMPLE_TIME
+} from './constants.js';
+import { canvas, canvasWidth } from './globals.js';
+import {
+  showSettings,
+  toggleSettings,
+  hideSettings,
+  isJoystickEnabled
+} from './settings.js';
+import { SwipeController } from './swipe.js';
+import { JoystickController } from './joystick.js';
+
+export class InputHandler {
+  constructor(game, ensureReset) {
+    this.game = game;
+    this.ensureReset = ensureReset;
+
+    this.touchStart = null;
+    this.touchSamples = [];
+    this.touchSwipe = false;
+    this.touchContext = null;
+
+    this.mouseStart = null;
+    this.mouseSamples = [];
+    this.isMouseDragging = false;
+    this.mouseSwipe = false;
+    this.mouseContext = null;
+
+    // Keyboard jump charge (space)
+    this.keyboardCharging = false;
+    this.keyboardChargeStart = 0;
+
+    // Keyboard movement (arrow keys)
+    this.keyboardMovementCharging = false;
+    this.keyboardMovementDirection = { x: 0, y: 0 };
+    this.pressedKeys = new Set();
+
+    // Trackpad gesture support
+    this.trackpadGestureActive = false;
+    this.trackpadStartX = 0;
+    this.trackpadStartTime = 0;
+
+    // Arrow-key spawn debounce
+    this.lastArrowTime = 0;
+    this.arrowCooldownMs = 140;
+
+    this.swipeController = new SwipeController(game);
+    this.joystick = new JoystickController(game);
+
+    this.bind();
+  }
+
+  calculateDirection(startX, startY, currentX, currentY) {
+    const dx = currentX - startX;
+    const dy = currentY - startY;
+    const distance = Math.sqrt(dx * dx + dy * dy);
+
+    if (distance < 10) return { x: 0, y: 0, distance: 0 };
+
+    return {
+      x: dx / distance,
+      y: dy / distance,
+      distance
+    };
+  }
+
+  bind() {
+    // ----------------------------
+    // Touch
+    // ----------------------------
+    canvas.addEventListener('touchstart', (e) => {
+      e.preventDefault();
+      const touch = e.touches[0];
+      const rect = canvas.getBoundingClientRect();
+      const x = touch.clientX - rect.left;
+      const y = touch.clientY - rect.top;
+
+      if (x > canvasWidth - 50 && y < 50) {
+        toggleSettings();
+        if (!showSettings) this.ensureReset();
+        return;
+      }
+      if (showSettings) { hideSettings(); this.ensureReset(); return; }
+
+      const startPoint = { x, y, time: Date.now() };
+      this.touchStart = startPoint;
+      this.touchSamples = [{ ...startPoint }];
+      this.touchSwipe = false;
+      this.touchContext = {
+        spawnEnabled: isJoystickEnabled(),
+        startedOnGround: this.game.sprite.onGround
+      };
+
+      if (this.touchContext.spawnEnabled || this.touchContext.startedOnGround) {
+        this.joystick.start(startPoint, this.game.sprite, {
+          allowSpawn: this.touchContext.spawnEnabled,
+          startScreenY: y
+        });
+      } else {
+        this.joystick.cancel();
+      }
+
+      this.game.sprite.startCharging();
+      if (!this.game.sprite.onGround && this.game.sprite.vy > 0) {
+        this.game.sprite.startGliding();
+      }
+    }, { passive: false });
+
+    canvas.addEventListener('touchmove', (e) => {
+      e.preventDefault();
+      if (!this.touchStart || showSettings) return;
+
+      const t = e.touches[0];
+      const r = canvas.getBoundingClientRect();
+      const s = { x: t.clientX - r.left, y: t.clientY - r.top, time: Date.now() };
+      this.touchSamples.push(s);
+      const cutoff = s.time - VELOCITY_SAMPLE_TIME;
+      this.touchSamples = this.touchSamples.filter(q => q.time >= cutoff);
+
+      const dir = this.calculateDirection(this.touchStart.x, this.touchStart.y, s.x, s.y);
+      const dt = s.time - this.touchStart.time;
+      const spawnEnabled = this.touchContext ? this.touchContext.spawnEnabled : isJoystickEnabled();
+
+      if (this.game.sprite.onGround) {
+        this.joystick.update(s, this.game.sprite);
+      } else if (spawnEnabled) {
+        this.game.sprite.charging = false;
+        this.game.sprite.movementCharging = false;
+        this.joystick.update(s, this.game.sprite);
+      } else if (!this.touchSwipe && dir.distance >= MIN_SWIPE_DISTANCE && dt >= MIN_SWIPE_TIME) {
+        this.touchSwipe = true;
+        this.game.sprite.charging = false;
+        this.game.sprite.movementCharging = false;
+        this.joystick.cancel();
+      }
+
+      if (!this.game.sprite.onGround && this.game.sprite.vy > 0 && !this.game.sprite.gliding && this.game.energyBar.canUse()) {
+        this.game.sprite.startGliding();
+      }
+    }, { passive: false });
+
+    canvas.addEventListener('touchend', (e) => {
+      e.preventDefault();
+      if (!this.touchStart || showSettings) return;
+
+      const endTime = Date.now();
+      const last = this.touchSamples[this.touchSamples.length - 1] || this.touchStart;
+      const dx = last.x - this.touchStart.x;
+      const total = Math.max(1, endTime - this.touchStart.time);
+
+      const joystickResult = this.joystick.end({ ...last, time: endTime }, this.game.sprite);
+      let handled = joystickResult.handled;
+
+      if (!this.game.sprite.onGround && (!this.touchContext || !this.touchContext.spawnEnabled) && this.touchSwipe) {
+        this.swipeController.spawnFromGesture(dx, total, last.y);
+        handled = true;
+      }
+
+      if (!handled) {
+        this.game.sprite.releaseJump();
+      }
+
+      this.game.sprite.stopGliding();
       this.touchStart = null;
       this.touchSamples = [];
       this.touchSwipe = false;
-      this.isJoystickMode = false;
-  
+      this.touchContext = null;
+    }, { passive: false });
+
+    // ----------------------------
+    // Mouse
+    // ----------------------------
+    canvas.addEventListener('mousedown', (e) => {
+      const r = canvas.getBoundingClientRect();
+      const x = e.clientX - r.left;
+      const y = e.clientY - r.top;
+
+      if (x > canvasWidth - 50 && y < 50) {
+        toggleSettings();
+        if (!showSettings) this.ensureReset();
+        return;
+      }
+      if (showSettings) { hideSettings(); this.ensureReset(); return; }
+
+      const startPoint = { x, y, time: Date.now() };
+      this.mouseStart = startPoint;
+      this.mouseSamples = [{ ...startPoint }];
+      this.isMouseDragging = true;
+      this.mouseSwipe = false;
+      this.mouseContext = {
+        spawnEnabled: isJoystickEnabled(),
+        startedOnGround: this.game.sprite.onGround
+      };
+
+      if (this.mouseContext.spawnEnabled || this.mouseContext.startedOnGround) {
+        this.joystick.start(startPoint, this.game.sprite, {
+          allowSpawn: this.mouseContext.spawnEnabled,
+          startScreenY: y
+        });
+      } else {
+        this.joystick.cancel();
+      }
+
+      this.game.sprite.startCharging();
+      if (!this.game.sprite.onGround && this.game.sprite.vy > 0) {
+        this.game.sprite.startGliding();
+      }
+    });
+
+    canvas.addEventListener('mousemove', (e) => {
+      if (!this.isMouseDragging || showSettings) return;
+
+      const r = canvas.getBoundingClientRect();
+      const s = { x: e.clientX - r.left, y: e.clientY - r.top, time: Date.now() };
+      this.mouseSamples.push(s);
+      const cutoff = s.time - VELOCITY_SAMPLE_TIME;
+      this.mouseSamples = this.mouseSamples.filter(q => q.time >= cutoff);
+
+      const dir = this.calculateDirection(this.mouseStart.x, this.mouseStart.y, s.x, s.y);
+      const dt = s.time - this.mouseStart.time;
+      const spawnEnabled = this.mouseContext ? this.mouseContext.spawnEnabled : isJoystickEnabled();
+
+      if (this.game.sprite.onGround) {
+        this.joystick.update(s, this.game.sprite);
+      } else if (spawnEnabled) {
+        this.game.sprite.charging = false;
+        this.game.sprite.movementCharging = false;
+        this.joystick.update(s, this.game.sprite);
+      } else if (!this.mouseSwipe && dir.distance >= MIN_SWIPE_DISTANCE && dt >= MIN_SWIPE_TIME) {
+        this.mouseSwipe = true;
+        this.game.sprite.charging = false;
+        this.game.sprite.movementCharging = false;
+        this.joystick.cancel();
+      }
+
+      if (!this.game.sprite.onGround && this.game.sprite.vy > 0 && !this.game.sprite.gliding && this.game.energyBar.canUse()) {
+        this.game.sprite.startGliding();
+      }
+    });
+
+    canvas.addEventListener('mouseup', () => {
+      if (!this.mouseStart || showSettings) return;
+
+      const endTime = Date.now();
+      const last = this.mouseSamples[this.mouseSamples.length - 1] || this.mouseStart;
+      const dx = last.x - this.mouseStart.x;
+      const total = Math.max(1, endTime - this.mouseStart.time);
+
+      const joystickResult = this.joystick.end({ ...last, time: endTime }, this.game.sprite);
+      let handled = joystickResult.handled;
+
+      if (!this.game.sprite.onGround && (!this.mouseContext || !this.mouseContext.spawnEnabled) && this.mouseSwipe) {
+        this.swipeController.spawnFromGesture(dx, total, last.y);
+        handled = true;
+      }
+
+      if (!handled) {
+        this.game.sprite.releaseJump();
+      }
+
+      this.game.sprite.stopGliding();
+      this.isMouseDragging = false;
       this.mouseStart = null;
       this.mouseSamples = [];
-      this.isMouseDragging = false;
       this.mouseSwipe = false;
-      this.isMouseJoystickMode = false;
-  
-      // Keyboard jump charge (space)
-      this.keyboardCharging = false;
-      this.keyboardChargeStart = 0;
+      this.mouseContext = null;
+    });
 
-      // Keyboard movement (arrow keys)
-      this.keyboardMovementCharging = false;
-      this.keyboardMovementDirection = { x: 0, y: 0 };
-      this.pressedKeys = new Set();
-  
-      // Trackpad gesture support
-      this.trackpadGestureActive = false;
-      this.trackpadStartX = 0;
-      this.trackpadStartTime = 0;
-  
-      // Arrow-key spawn debounce
-      this.lastArrowTime = 0;
-      this.arrowCooldownMs = 140;
-  
-      this.bind();
-    }
+    // ----------------------------
+    // Trackpad (two-finger horizontal swipe)
+    // ----------------------------
+    canvas.addEventListener('wheel', (e) => {
+      if (showSettings) return;
 
-    calculateDirection(startX, startY, currentX, currentY) {
-      const dx = currentX - startX;
-      const dy = currentY - startY;
-      const distance = Math.sqrt(dx * dx + dy * dy);
-      
-      if (distance < 10) return { x: 0, y: 0, distance: 0 };
-      
-      return {
-        x: dx / distance,
-        y: dy / distance,
-        distance: distance
-      };
-    }
-  
-    bind() {
-      // ----------------------------
-      // Touch
-      // ----------------------------
-      canvas.addEventListener('touchstart', (e) => {
+      if (Math.abs(e.deltaX) > Math.abs(e.deltaY) && Math.abs(e.deltaX) > 10) {
         e.preventDefault();
-        const touch = e.touches[0];
-        const rect = canvas.getBoundingClientRect();
-        const x = touch.clientX - rect.left;
-        const y = touch.clientY - rect.top;
-  
-        // toggle settings
-        if (x > canvasWidth - 50 && y < 50) {
-          toggleSettings();
-          if (!showSettings) this.ensureReset();
+
+        if (!this.trackpadGestureActive) {
+          this.trackpadGestureActive = true;
+          this.trackpadStartX = e.deltaX;
+          this.trackpadStartTime = Date.now();
           return;
         }
-        if (showSettings) { hideSettings(); this.ensureReset(); return; }
-  
-        this.touchStart = { x, y, time: Date.now() };
-        this.touchSamples = [{ ...this.touchStart }];
-        this.touchSwipe = false;
-        this.isJoystickMode = false;
-  
-        // Always start with jump charging
-        this.game.sprite.startCharging();
-        if (!this.game.sprite.onGround && this.game.sprite.vy > 0) {
-          this.game.sprite.startGliding();
-        }
-      }, { passive: false });
-  
-      canvas.addEventListener('touchmove', (e) => {
-        e.preventDefault();
-        if (!this.touchStart || showSettings) return;
-        
-        const t = e.touches[0];
-        const r = canvas.getBoundingClientRect();
-        const s = { x: t.clientX - r.left, y: t.clientY - r.top, time: Date.now() };
-        this.touchSamples.push(s);
-        const cutoff = s.time - VELOCITY_SAMPLE_TIME;
-        this.touchSamples = this.touchSamples.filter(q => q.time >= cutoff);
-  
-        const direction = this.calculateDirection(this.touchStart.x, this.touchStart.y, s.x, s.y);
-        const dt = s.time - this.touchStart.time;
-        
-        // Determine if this is a joystick movement or platform spawn swipe
-        if (!this.touchSwipe && !this.isJoystickMode && direction.distance >= MIN_SWIPE_DISTANCE && dt >= MIN_SWIPE_TIME) {
-          // Check if sprite is airborne (required for platform spawning)
-          if (!this.game.sprite.onGround) {
-            this.touchSwipe = true;
-            this.game.sprite.charging = false;
-            this.game.sprite.movementCharging = false;
-          } else {
-            // Switch to joystick mode if on ground
-            this.isJoystickMode = true;
-            this.game.sprite.charging = false;
-            this.game.sprite.startMovementCharging(direction);
-          }
-        } else if (this.isJoystickMode) {
-          // Update joystick direction
-          this.game.sprite.updateMovementCharging(direction);
-        }
 
-        if (!this.game.sprite.onGround && this.game.sprite.vy > 0 && !this.game.sprite.gliding && this.game.energyBar.canUse()) {
-          this.game.sprite.startGliding();
-        }
-      }, { passive: false });
-  
-      canvas.addEventListener('touchend', (e) => {
-        e.preventDefault();
-        if (!this.touchStart || showSettings) return;
-        
-        const endTime = Date.now();
-        const last = this.touchSamples[this.touchSamples.length - 1] || this.touchStart;
-        const dx = last.x - this.touchStart.x;
-        const total = Math.max(1, endTime - this.touchStart.time);
-  
-        if (this.touchSwipe && !this.game.sprite.onGround) {
-          this.createPlatformFromGesture(dx, total, last.y);
-        } else if (this.isJoystickMode) {
-          this.game.sprite.releaseMovement();
-        } else {
-          this.game.sprite.releaseJump();
-        }
-  
-        this.game.sprite.stopGliding();
-        this.touchStart = null; 
-        this.touchSamples = []; 
-        this.touchSwipe = false;
-        this.isJoystickMode = false;
-      }, { passive: false });
-  
-      // ----------------------------
-      // Mouse
-      // ----------------------------
-      canvas.addEventListener('mousedown', (e) => {
-        const r = canvas.getBoundingClientRect();
-        const x = e.clientX - r.left;
-        const y = e.clientY - r.top;
-  
-        if (x > canvasWidth - 50 && y < 50) {
-          toggleSettings();
-          if (!showSettings) this.ensureReset();
-          return;
-        }
-        if (showSettings) { hideSettings(); this.ensureReset(); return; }
-  
-        this.mouseStart = { x, y, time: Date.now() };
-        this.mouseSamples = [{ ...this.mouseStart }];
-        this.isMouseDragging = true;
-        this.mouseSwipe = false;
-        this.isMouseJoystickMode = false;
-  
-        this.game.sprite.startCharging();
-        if (!this.game.sprite.onGround && this.game.sprite.vy > 0) {
-          this.game.sprite.startGliding();
-        }
-      });
-  
-      canvas.addEventListener('mousemove', (e) => {
-        if (!this.isMouseDragging || showSettings) return;
-        
-        const r = canvas.getBoundingClientRect();
-        const s = { x: e.clientX - r.left, y: e.clientY - r.top, time: Date.now() };
-        this.mouseSamples.push(s);
-        const cutoff = s.time - VELOCITY_SAMPLE_TIME;
-        this.mouseSamples = this.mouseSamples.filter(q => q.time >= cutoff);
-  
-        const direction = this.calculateDirection(this.mouseStart.x, this.mouseStart.y, s.x, s.y);
-        const dt = s.time - this.mouseStart.time;
-        
-        if (!this.mouseSwipe && !this.isMouseJoystickMode && direction.distance >= MIN_SWIPE_DISTANCE && dt >= MIN_SWIPE_TIME) {
-          if (!this.game.sprite.onGround) {
-            this.mouseSwipe = true;
-            this.game.sprite.charging = false;
-            this.game.sprite.movementCharging = false;
-          } else {
-            this.isMouseJoystickMode = true;
-            this.game.sprite.charging = false;
-            this.game.sprite.startMovementCharging(direction);
-          }
-        } else if (this.isMouseJoystickMode) {
-          this.game.sprite.updateMovementCharging(direction);
-        }
+        const currentTime = Date.now();
+        const totalDeltaX = e.deltaX - this.trackpadStartX;
+        const totalTime = currentTime - this.trackpadStartTime;
 
-        if (!this.game.sprite.onGround && this.game.sprite.vy > 0 && !this.game.sprite.gliding && this.game.energyBar.canUse()) {
-          this.game.sprite.startGliding();
-        }
-      });
-  
-      canvas.addEventListener('mouseup', () => {
-        if (!this.mouseStart || showSettings) return;
-        
-        const endTime = Date.now();
-        const last = this.mouseSamples[this.mouseSamples.length - 1] || this.mouseStart;
-        const dx = last.x - this.mouseStart.x;
-        const total = Math.max(1, endTime - this.mouseStart.time);
-  
-        if (this.mouseSwipe && !this.game.sprite.onGround) {
-          this.createPlatformFromGesture(dx, total, last.y);
-        } else if (this.isMouseJoystickMode) {
-          this.game.sprite.releaseMovement();
-        } else {
-          this.game.sprite.releaseJump();
-        }
-  
-        this.game.sprite.stopGliding();
-        this.isMouseDragging = false;
-        this.mouseStart = null;
-        this.mouseSamples = [];
-        this.mouseSwipe = false;
-        this.isMouseJoystickMode = false;
-      });
-  
-      // ----------------------------
-      // Trackpad (two-finger horizontal swipe)
-      // ----------------------------
-      canvas.addEventListener('wheel', (e) => {
-        if (showSettings) return;
-  
-        if (Math.abs(e.deltaX) > Math.abs(e.deltaY) && Math.abs(e.deltaX) > 10) {
-          e.preventDefault();
-  
-          if (!this.trackpadGestureActive) {
-            this.trackpadGestureActive = true;
-            this.trackpadStartX = e.deltaX;
-            this.trackpadStartTime = Date.now();
-            return;
-          }
-  
-          const currentTime = Date.now();
-          const totalDeltaX = e.deltaX - this.trackpadStartX;
-          const totalTime = currentTime - this.trackpadStartTime;
-  
-          if (Math.abs(totalDeltaX) > 50 && totalTime > 100 && !this.game.sprite.onGround) {
-            const rect = canvas.getBoundingClientRect();
-            const mouseY = e.clientY - rect.top;
-            this.createPlatformFromGesture(totalDeltaX, totalTime, mouseY);
-            this.trackpadGestureActive = false;
-          }
-        } else {
+        if (Math.abs(totalDeltaX) > 50 && totalTime > 100 && !this.game.sprite.onGround) {
+          const rect = canvas.getBoundingClientRect();
+          const mouseY = e.clientY - rect.top;
+          this.swipeController.spawnFromGesture(totalDeltaX, totalTime, mouseY);
           this.trackpadGestureActive = false;
         }
-      }, { passive: false });
-  
-      canvas.addEventListener('mouseleave', () => {
+      } else {
         this.trackpadGestureActive = false;
-      });
-  
-      // ----------------------------
-      // Keyboard: Jump (Space)
-      // ----------------------------
-      document.addEventListener('keydown', (e) => {
-        if (e.code === 'Space' && !showSettings && !this.keyboardCharging) {
-          e.preventDefault();
-          this.keyboardCharging = true;
-          this.keyboardChargeStart = Date.now();
-          this.game.sprite.startCharging();
-          if (!this.game.sprite.onGround && this.game.sprite.vy > 0) this.game.sprite.startGliding();
-        }
-
-        // ----------------------------
-        // Keyboard: Arrow keys for joystick movement
-        // ----------------------------
-        if (!showSettings && ['ArrowUp', 'ArrowDown', 'ArrowLeft', 'ArrowRight'].includes(e.code)) {
-          e.preventDefault();
-          this.pressedKeys.add(e.code);
-          
-          if (!this.keyboardMovementCharging) {
-            this.keyboardMovementCharging = true;
-            this.updateKeyboardMovementDirection();
-            this.game.sprite.startMovementCharging(this.keyboardMovementDirection);
-          } else {
-            this.updateKeyboardMovementDirection();
-            this.game.sprite.updateMovementCharging(this.keyboardMovementDirection);
-          }
-        }
-      });
-  
-      document.addEventListener('keyup', (e) => {
-        if (e.code === 'Space' && !showSettings && this.keyboardCharging) {
-          e.preventDefault();
-          this.keyboardCharging = false;
-          this.game.sprite.releaseJump();
-          this.game.sprite.stopGliding();
-        }
-
-        if (!showSettings && ['ArrowUp', 'ArrowDown', 'ArrowLeft', 'ArrowRight'].includes(e.code)) {
-          e.preventDefault();
-          this.pressedKeys.delete(e.code);
-          
-          if (this.pressedKeys.size === 0 && this.keyboardMovementCharging) {
-            this.keyboardMovementCharging = false;
-            this.game.sprite.releaseMovement();
-          } else if (this.keyboardMovementCharging) {
-            this.updateKeyboardMovementDirection();
-            this.game.sprite.updateMovementCharging(this.keyboardMovementDirection);
-          }
-        }
-      });
-  
-      // Prevent space from scrolling the page
-      document.addEventListener('keydown', (e) => {
-        if (e.code === 'Space' || ['ArrowUp', 'ArrowDown', 'ArrowLeft', 'ArrowRight'].includes(e.code)) {
-          e.preventDefault();
-        }
-      });
-    }
-
-    updateKeyboardMovementDirection() {
-      let x = 0, y = 0;
-      
-      if (this.pressedKeys.has('ArrowLeft')) x -= 1;
-      if (this.pressedKeys.has('ArrowRight')) x += 1;
-      if (this.pressedKeys.has('ArrowUp')) y -= 1;
-      if (this.pressedKeys.has('ArrowDown')) y += 1;
-      
-      // Normalize diagonal movement
-      const length = Math.sqrt(x * x + y * y);
-      if (length > 0) {
-        x /= length;
-        y /= length;
       }
-      
-      this.keyboardMovementDirection = { x, y };
-    }
-  
-    /**
-     * Creates a platform from a left/right swipe or trackpad gesture.
-     * Spawns from the corresponding canvas edge and moves inward.
-     * Only works when sprite is airborne.
-     */
-    createPlatformFromGesture(dx, totalTimeMs, screenY) {
-      if (this.game.sprite.onGround) return; // Prevent platform spawning when grounded
-      
-      const activeMovers = this.game.platforms.filter(p => p.direction !== 0).length;
-      if (activeMovers >= MAX_PLATFORMS) return;
-  
-      const dir = (dx >= 0) ? 1 : -1;
-      const speedRaw = Math.abs(dx) / (totalTimeMs / 1000);
-      const speed = clamp(speedRaw, MIN_PLATFORM_SPEED, MAX_PLATFORM_SPEED);
-  
-      const w = clamp(
-        PLATFORM_MIN_WIDTH + (PLATFORM_MAX_WIDTH - PLATFORM_MIN_WIDTH) * (totalTimeMs / 700),
-        PLATFORM_MIN_WIDTH, PLATFORM_MAX_WIDTH
-      );
-  
-      const worldY = screenY + cameraY;
-      const x = (dir > 0) ? -w : canvasWidth;
-      const platform = new Platform(x, worldY, w, speed, dir);
-      this.game.platforms.push(platform);
-    }
+    }, { passive: false });
+
+    canvas.addEventListener('mouseleave', () => {
+      this.trackpadGestureActive = false;
+    });
+
+    // ----------------------------
+    // Keyboard: Jump (Space)
+    // ----------------------------
+    document.addEventListener('keydown', (e) => {
+      if (e.code === 'Space' && !showSettings && !this.keyboardCharging) {
+        e.preventDefault();
+        this.keyboardCharging = true;
+        this.keyboardChargeStart = Date.now();
+        this.game.sprite.startCharging();
+        if (!this.game.sprite.onGround && this.game.sprite.vy > 0) this.game.sprite.startGliding();
+      }
+
+      if (!showSettings && ['ArrowUp', 'ArrowDown', 'ArrowLeft', 'ArrowRight'].includes(e.code)) {
+        e.preventDefault();
+        this.pressedKeys.add(e.code);
+
+        if (!this.keyboardMovementCharging) {
+          this.keyboardMovementCharging = true;
+          this.updateKeyboardMovementDirection();
+          this.game.sprite.startMovementCharging(this.keyboardMovementDirection);
+        } else {
+          this.updateKeyboardMovementDirection();
+          this.game.sprite.updateMovementCharging(this.keyboardMovementDirection);
+        }
+      }
+    });
+
+    document.addEventListener('keyup', (e) => {
+      if (e.code === 'Space' && !showSettings && this.keyboardCharging) {
+        e.preventDefault();
+        this.keyboardCharging = false;
+        this.game.sprite.releaseJump();
+        this.game.sprite.stopGliding();
+      }
+
+      if (!showSettings && ['ArrowUp', 'ArrowDown', 'ArrowLeft', 'ArrowRight'].includes(e.code)) {
+        e.preventDefault();
+        this.pressedKeys.delete(e.code);
+
+        if (this.pressedKeys.size === 0 && this.keyboardMovementCharging) {
+          this.keyboardMovementCharging = false;
+          this.game.sprite.releaseMovement();
+        } else if (this.keyboardMovementCharging) {
+          this.updateKeyboardMovementDirection();
+          this.game.sprite.updateMovementCharging(this.keyboardMovementDirection);
+        }
+      }
+    });
+
+    // Prevent space from scrolling the page
+    document.addEventListener('keydown', (e) => {
+      if (e.code === 'Space' || ['ArrowUp', 'ArrowDown', 'ArrowLeft', 'ArrowRight'].includes(e.code)) {
+        e.preventDefault();
+      }
+    });
   }
+
+  updateKeyboardMovementDirection() {
+    let x = 0;
+    let y = 0;
+
+    if (this.pressedKeys.has('ArrowLeft')) x -= 1;
+    if (this.pressedKeys.has('ArrowRight')) x += 1;
+    if (this.pressedKeys.has('ArrowUp')) y -= 1;
+    if (this.pressedKeys.has('ArrowDown')) y += 1;
+
+    const length = Math.sqrt(x * x + y * y);
+    if (length > 0) {
+      x /= length;
+      y /= length;
+    }
+
+    this.keyboardMovementDirection = { x, y };
+  }
+
+  draw(ctx) {
+    this.joystick.draw(ctx);
+  }
+}

--- a/js/joystick.js
+++ b/js/joystick.js
@@ -1,0 +1,221 @@
+import {
+  MIN_PLATFORM_SPEED,
+  MAX_PLATFORM_SPEED,
+  MAX_PLATFORMS,
+  SPRITE_SIZE
+} from './constants.js';
+import { canvasWidth, cameraY } from './globals.js';
+import { Platform } from './platforms.js';
+import { clamp } from './utils.js';
+
+const RAD_TO_DEG = 180 / Math.PI;
+const MOVEMENT_THRESHOLD = 14;
+const SPAWN_THRESHOLD = 12;
+const MAX_ROTATION_DEG_PER_SEC = 720;
+const MIN_ROTATION_DEGREES = 8;
+
+export class JoystickController {
+  constructor(game) {
+    this.game = game;
+    this.active = false;
+    this.center = { x: 0, y: 0 };
+    this.current = { x: 0, y: 0 };
+    this.mode = null;
+    this.movementActive = false;
+    this.allowSpawn = false;
+    this.startedOnGround = true;
+    this.startTime = 0;
+    this.startScreenY = 0;
+    this.lastAngle = null;
+    this.accumulatedAngle = 0;
+    this.outerRadius = 32;
+    this.innerRadius = 10;
+  }
+
+  start(point, sprite, options = {}) {
+    this.reset();
+    this.active = true;
+    this.center = { x: point.x, y: point.y };
+    this.current = { x: point.x, y: point.y };
+    this.startTime = point.time || Date.now();
+    this.startScreenY = options.startScreenY ?? point.y;
+    this.startedOnGround = sprite.onGround;
+    this.allowSpawn = Boolean(options.allowSpawn) && !this.startedOnGround;
+    this.mode = null;
+    this.movementActive = false;
+    this.lastAngle = null;
+    this.accumulatedAngle = 0;
+  }
+
+  update(point, sprite) {
+    if (!this.active) return;
+    this.current = { x: point.x, y: point.y };
+
+    if (!sprite.onGround && this.allowSpawn) {
+      this._updateSpawn();
+      return;
+    }
+
+    if (sprite.onGround) {
+      this._updateMovement(sprite);
+    }
+  }
+
+  end(point, sprite) {
+    if (!this.active) return { handled: false, spawned: false };
+
+    let handled = false;
+    let spawned = false;
+
+    if (this.mode === 'movement' && this.movementActive) {
+      sprite.releaseMovement();
+      handled = true;
+    } else if (this.mode === 'spawn' && this.allowSpawn) {
+      const result = this._spawnPlatform(point.time || Date.now());
+      spawned = result;
+      handled = true;
+    }
+
+    this.reset();
+    return { handled, spawned };
+  }
+
+  cancel() {
+    this.reset();
+  }
+
+  reset() {
+    this.active = false;
+    this.mode = null;
+    this.movementActive = false;
+    this.allowSpawn = false;
+    this.startedOnGround = true;
+    this.startTime = 0;
+    this.startScreenY = 0;
+    this.lastAngle = null;
+    this.accumulatedAngle = 0;
+  }
+
+  draw(ctx) {
+    if (!this.active) return;
+
+    ctx.save();
+    ctx.strokeStyle = 'rgba(255,255,255,0.75)';
+    ctx.lineWidth = 2;
+    ctx.beginPath();
+    ctx.arc(this.center.x, this.center.y, this.outerRadius, 0, Math.PI * 2);
+    ctx.stroke();
+
+    const dx = this.current.x - this.center.x;
+    const dy = this.current.y - this.center.y;
+    const dist = Math.sqrt(dx * dx + dy * dy);
+    const angle = dist > 0 ? Math.atan2(dy, dx) : 0;
+    const clampedDist = Math.min(dist, this.outerRadius - this.innerRadius);
+    const knobX = this.center.x + Math.cos(angle) * clampedDist;
+    const knobY = this.center.y + Math.sin(angle) * clampedDist;
+
+    ctx.fillStyle = 'rgba(255,255,255,0.18)';
+    ctx.beginPath();
+    ctx.arc(this.center.x, this.center.y, this.outerRadius - 6, 0, Math.PI * 2);
+    ctx.fill();
+
+    ctx.fillStyle = '#ffffff';
+    ctx.beginPath();
+    ctx.arc(knobX, knobY, this.innerRadius, 0, Math.PI * 2);
+    ctx.fill();
+
+    ctx.restore();
+  }
+
+  _updateMovement(sprite) {
+    const dx = this.current.x - this.center.x;
+    const dy = this.current.y - this.center.y;
+    const distance = Math.hypot(dx, dy);
+
+    if (distance < MOVEMENT_THRESHOLD) return;
+
+    const direction = {
+      x: dx / distance,
+      y: dy / distance
+    };
+
+    if (!this.movementActive) {
+      sprite.charging = false;
+      sprite.startMovementCharging(direction);
+      this.mode = 'movement';
+      this.movementActive = true;
+    } else {
+      sprite.updateMovementCharging(direction);
+    }
+  }
+
+  _updateSpawn() {
+    const dx = this.current.x - this.center.x;
+    const dy = this.current.y - this.center.y;
+    const distance = Math.hypot(dx, dy);
+    if (distance < SPAWN_THRESHOLD) return;
+
+    const angle = Math.atan2(dy, dx);
+    if (this.mode !== 'spawn') {
+      this.mode = 'spawn';
+      this.lastAngle = angle;
+      this.accumulatedAngle = 0;
+      return;
+    }
+
+    let delta = angle - this.lastAngle;
+    if (delta > Math.PI) delta -= Math.PI * 2;
+    if (delta < -Math.PI) delta += Math.PI * 2;
+
+    this.accumulatedAngle += delta;
+    this.lastAngle = angle;
+  }
+
+  _spawnPlatform(endTime) {
+    const rotationDegrees = Math.min(360, Math.abs(this.accumulatedAngle) * RAD_TO_DEG);
+    if (rotationDegrees < MIN_ROTATION_DEGREES) return false;
+
+    const activeMovers = this.game.platforms.filter(p => p && p.active !== false && p.direction !== 0).length;
+    if (activeMovers >= MAX_PLATFORMS) return false;
+
+    const baseWidth = this._getReferencePlatformWidth();
+    const maxLength = Math.max(SPRITE_SIZE * 2, baseWidth * 0.9);
+    const ratio = rotationDegrees / 360;
+    const width = clamp(maxLength * ratio, SPRITE_SIZE * 2, maxLength);
+
+    const durationMs = Math.max(16, (endTime || Date.now()) - this.startTime);
+    const angularSpeed = rotationDegrees / (durationMs / 1000);
+    const speedRatio = clamp(angularSpeed / MAX_ROTATION_DEG_PER_SEC, 0, 1);
+    const speed = MIN_PLATFORM_SPEED + (MAX_PLATFORM_SPEED - MIN_PLATFORM_SPEED) * speedRatio;
+
+    const direction = this.accumulatedAngle >= 0 ? 1 : -1;
+    const worldY = this.startScreenY + cameraY;
+    const startX = direction > 0 ? -width : canvasWidth;
+
+    const platform = new Platform(startX, worldY, width, speed, direction);
+    this.game.platforms.push(platform);
+    return true;
+  }
+
+  _getReferencePlatformWidth() {
+    const sprite = this.game.sprite;
+    if (!sprite) return canvasWidth * 0.6;
+
+    let bestWidth = canvasWidth * 0.6;
+    let bestDelta = Infinity;
+    for (const platform of this.game.platforms) {
+      if (!(platform instanceof Platform)) continue;
+      if (!platform.active) continue;
+      const moving = Math.abs(platform.speed) > 0 && Math.abs(platform.direction || 0) > 0;
+      if (moving) continue;
+
+      const delta = platform.y - sprite.y;
+      if (delta >= 0 && delta < bestDelta) {
+        bestDelta = delta;
+        bestWidth = platform.width;
+      }
+    }
+
+    return Math.max(bestWidth, SPRITE_SIZE * 2);
+  }
+}

--- a/js/settings.js
+++ b/js/settings.js
@@ -7,6 +7,12 @@ export function hideSettings() { showSettings = false; }
 
 let overlay = null;
 
+let joystickEnabled = true;
+export function isJoystickEnabled() { return joystickEnabled; }
+export function setJoystickEnabled(value) {
+  joystickEnabled = Boolean(value);
+}
+
 export function drawSettingsIcon(ctx) {
   const iconSize = 20;
   const iconX = canvasWidth - 30;
@@ -22,6 +28,45 @@ export function drawSettingsIcon(ctx) {
   ctx.beginPath();
   ctx.arc(iconX, iconY, iconSize / 4, 0, Math.PI * 2);
   ctx.fill();
+}
+
+function createJoystickToggle(onChange) {
+  const container = document.createElement('div');
+  container.style.display = 'flex';
+  container.style.alignItems = 'center';
+  container.style.justifyContent = 'space-between';
+  container.style.margin = '10px';
+  container.style.padding = '8px 12px';
+  container.style.border = '2px solid #fff';
+  container.style.background = '#000';
+
+  const label = document.createElement('span');
+  label.textContent = 'Joystick Spawn';
+  label.style.fontFamily = 'LocalPressStart, monospace';
+  label.style.fontSize = '10px';
+  label.style.letterSpacing = '1px';
+  label.style.color = '#fff';
+
+  const toggle = document.createElement('button');
+  toggle.textContent = joystickEnabled ? 'ON' : 'OFF';
+  toggle.style.fontFamily = 'LocalPressStart, monospace';
+  toggle.style.fontSize = '10px';
+  toggle.style.padding = '6px 12px';
+  toggle.style.border = '2px solid #fff';
+  toggle.style.background = joystickEnabled ? '#1a1a1a' : '#000';
+  toggle.style.color = '#fff';
+  toggle.style.cursor = 'pointer';
+
+  toggle.addEventListener('click', () => {
+    joystickEnabled = !joystickEnabled;
+    toggle.textContent = joystickEnabled ? 'ON' : 'OFF';
+    toggle.style.background = joystickEnabled ? '#1a1a1a' : '#000';
+    if (typeof onChange === 'function') onChange(joystickEnabled);
+  });
+
+  container.appendChild(label);
+  container.appendChild(toggle);
+  return container;
 }
 
 export function drawSettings(onPlay) {
@@ -41,37 +86,64 @@ export function drawSettings(onPlay) {
   overlay.style.left = '0';
   overlay.style.width = '100%';
   overlay.style.height = '100%';
-  overlay.style.background = 'rgba(0,0,0,0.8)';
+  overlay.style.background = 'rgba(0,0,0,0.88)';
   overlay.style.display = 'flex';
   overlay.style.alignItems = 'center';
   overlay.style.justifyContent = 'center';
 
   const panel = document.createElement('div');
-  panel.style.background = '#2a2a2a';
-  panel.style.border = '1px solid #555';
+  panel.style.background = '#000';
+  panel.style.border = '3px solid #fff';
   panel.style.width = '80%';
-  panel.style.maxWidth = '400px';
+  panel.style.maxWidth = '420px';
   panel.style.height = '80%';
-  panel.style.maxHeight = '500px';
+  panel.style.maxHeight = '520px';
   panel.style.display = 'flex';
   panel.style.flexDirection = 'column';
+  panel.style.boxShadow = '0 0 18px rgba(255,255,255,0.15)';
 
   const title = document.createElement('h3');
   title.textContent = 'Budget Settings';
   title.style.color = '#fff';
-  title.style.fontFamily = 'Arial';
-  title.style.margin = '10px 0';
+  title.style.fontFamily = 'LocalPressStart, monospace';
+  title.style.fontSize = '12px';
+  title.style.letterSpacing = '1px';
+  title.style.margin = '12px 0 4px';
   title.style.textAlign = 'center';
+
+  const joystickRow = createJoystickToggle();
+
+  const textareaLabel = document.createElement('span');
+  textareaLabel.textContent = 'Budget JSON';
+  textareaLabel.style.fontFamily = 'LocalPressStart, monospace';
+  textareaLabel.style.fontSize = '10px';
+  textareaLabel.style.color = '#fff';
+  textareaLabel.style.margin = '0 10px';
 
   const textarea = document.createElement('textarea');
   textarea.style.flex = '1';
   textarea.style.margin = '10px';
+  textarea.style.padding = '10px';
+  textarea.style.background = '#050505';
+  textarea.style.color = '#fff';
+  textarea.style.border = '2px solid #fff';
+  textarea.style.fontFamily = 'LocalPressStart, monospace';
+  textarea.style.fontSize = '10px';
+  textarea.style.lineHeight = '1.4';
   textarea.value = JSON.stringify(budgetData, null, 2);
 
   const playButton = document.createElement('button');
-  playButton.textContent = 'Play';
-  playButton.style.margin = '10px auto';
-  playButton.style.padding = '8px 16px';
+  playButton.textContent = 'PLAY';
+  playButton.style.margin = '12px auto 16px';
+  playButton.style.padding = '10px 18px';
+  playButton.style.border = '3px solid #fff';
+  playButton.style.background = '#000';
+  playButton.style.color = '#fff';
+  playButton.style.fontFamily = 'LocalPressStart, monospace';
+  playButton.style.fontSize = '12px';
+  playButton.style.cursor = 'pointer';
+  playButton.style.textTransform = 'uppercase';
+
   playButton.addEventListener('click', () => {
     try {
       const parsed = JSON.parse(textarea.value);
@@ -87,6 +159,8 @@ export function drawSettings(onPlay) {
   });
 
   panel.appendChild(title);
+  panel.appendChild(joystickRow);
+  panel.appendChild(textareaLabel);
   panel.appendChild(textarea);
   panel.appendChild(playButton);
   overlay.appendChild(panel);

--- a/js/swipe.js
+++ b/js/swipe.js
@@ -1,0 +1,41 @@
+import {
+  MIN_PLATFORM_SPEED,
+  MAX_PLATFORM_SPEED,
+  MAX_PLATFORMS,
+  PLATFORM_MIN_WIDTH,
+  PLATFORM_MAX_WIDTH
+} from './constants.js';
+import { canvasWidth, cameraY } from './globals.js';
+import { Platform } from './platforms.js';
+import { clamp } from './utils.js';
+
+export class SwipeController {
+  constructor(game) {
+    this.game = game;
+  }
+
+  spawnFromGesture(dx, totalTimeMs, screenY) {
+    if (this.game.sprite.onGround) return;
+
+    const activeMovers = this.game.platforms.filter(p => p && p.active !== false && p.direction !== 0).length;
+    if (activeMovers >= MAX_PLATFORMS) return;
+
+    const dir = dx >= 0 ? 1 : -1;
+    const duration = Math.max(1, totalTimeMs);
+    const speedRaw = Math.abs(dx) / (duration / 1000);
+    const speed = clamp(speedRaw, MIN_PLATFORM_SPEED, MAX_PLATFORM_SPEED);
+
+    const widthFactor = clamp(duration / 700, 0, 1);
+    const width = clamp(
+      PLATFORM_MIN_WIDTH + (PLATFORM_MAX_WIDTH - PLATFORM_MIN_WIDTH) * widthFactor,
+      PLATFORM_MIN_WIDTH,
+      PLATFORM_MAX_WIDTH
+    );
+
+    const worldY = screenY + cameraY;
+    const startX = dir > 0 ? -width : canvasWidth;
+
+    const platform = new Platform(startX, worldY, width, speed, dir);
+    this.game.platforms.push(platform);
+  }
+}


### PR DESCRIPTION
## Summary
- refactor the input handler to delegate swipe spawning and integrate a reusable joystick controller for both grounded movement and airborne platform creation
- add dedicated joystick and swipe modules so joystick rotation determines spawn length, speed, and direction while swipes retain their prior behaviour
- refresh the settings overlay with an 8-bit style joystick toggle and draw the temporary joystick during gameplay when active

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68c865f5e298832dbb55aa10c7fbf298