### PR TITLE
Implement card-based horizontal expansion and camera follow

### DIFF
--- a/src/core/globals.ts
+++ b/src/core/globals.ts
@@ -36,10 +36,12 @@ export const gameOverPanel: HTMLDivElement = gameOverPanelElement;
 export let canvasWidth = 0;
 export let canvasHeight = 0;
 export let groundY = 0;
+export let cameraX = 0;
 export let cameraY = 0;
 export let maxHeight = 0;
 
 export function setCameraY(v: number) { cameraY = v; }
+export function setCameraX(v: number) { cameraX = v; }
 export function addMaxHeight(v: number) { maxHeight = Math.max(maxHeight, v); }
 
 export function resize() {
@@ -85,15 +87,21 @@ export function drawBackgroundGrid() {
 
   const worldTop = cameraY;
   const worldBottom = cameraY + canvasHeight;
+  const worldLeft = cameraX;
+  const worldRight = cameraX + canvasWidth;
 
   let firstY = Math.floor(worldTop / GRID_SIZE) * GRID_SIZE;
   if (firstY > worldTop) firstY -= GRID_SIZE;
 
+  let firstX = Math.floor(worldLeft / GRID_SIZE) * GRID_SIZE;
+  if (firstX > worldLeft) firstX -= GRID_SIZE;
+
   for (let y = firstY; y <= worldBottom; y += GRID_SIZE) {
     const sy = y - cameraY;
-    for (let x = 0; x <= canvasWidth; x += GRID_SIZE) {
+    for (let x = firstX; x <= worldRight; x += GRID_SIZE) {
+      const sx = x - cameraX;
       ctx.beginPath();
-      ctx.arc(x, sy, 1.2, 0, Math.PI * 2); // radius ~1–2px looks nice
+      ctx.arc(sx, sy, 1.2, 0, Math.PI * 2); // radius ~1–2px looks nice
       ctx.fill();
     }
   }

--- a/src/core/globals.ts
+++ b/src/core/globals.ts
@@ -2,7 +2,10 @@ import { GRID_SIZE, CANVAS_MAX_WIDTH } from '../config/constants.js';
 
 type Sprite = import('../entities/sprite.js').Sprite;
 type Ride = import('../entities/rides.js').Ride;
-type Gate = import('../entities/gates.js').Gate | import('../entities/controlledGate.js').ControlledGate;
+type Gate =
+  | import('../entities/gates.js').Gate
+  | import('../entities/controlledGate.js').ControlledGate
+  | import('../entities/seamFloor.js').SeamFloor;
 type InputHandler = import('./input.js').InputHandler;
 type EnergyBar = import('../ui/hud.js').EnergyBar;
 type Hearts = import('../ui/hud.js').Hearts;

--- a/src/core/input.ts
+++ b/src/core/input.ts
@@ -4,7 +4,7 @@ import {
   VELOCITY_SAMPLE_TIME,
   MAX_RIDES,
 } from '../config/constants.js';
-import { canvas, canvasWidth, cameraY, type GameState } from './globals.js';
+import { canvas, canvasWidth, cameraX, cameraY, type GameState } from './globals.js';
 import { createRideFromInput, countActiveMovingRides } from '../entities/rides.js';
 import { showSettings, toggleSettings, hideSettings } from '../systems/settings.js';
 
@@ -14,6 +14,7 @@ type RideGesture = {
   distance: number;
   durationMs: number;
   screenY: number;
+  cameraX: number;
   cameraY: number;
   canvasWidth: number;
 };
@@ -433,6 +434,7 @@ export class InputHandler {
       distance: dx,
       durationMs: totalTimeMs,
       screenY,
+      cameraX,
       cameraY,
       canvasWidth,
     };

--- a/src/entities/collectibles.ts
+++ b/src/entities/collectibles.ts
@@ -51,9 +51,14 @@ export class Collectible {
     if (this.y > cameraY + canvasHeight + 200) this.active = false;
   }
 
-  draw(ctx: CanvasRenderingContext2D, cameraYValue: number, canvasHeightValue: number) {
+  draw(
+    ctx: CanvasRenderingContext2D,
+    cameraXValue: number,
+    cameraYValue: number,
+    canvasHeightValue: number
+  ) {
     if (!this.active) return;
-    const screenX = this.x;
+    const screenX = this.x - cameraXValue;
     const screenY = this.y - cameraYValue;
     if (screenY < -50 || screenY > canvasHeightValue + 50) return;
 

--- a/src/entities/controlledGate.ts
+++ b/src/entities/controlledGate.ts
@@ -286,10 +286,12 @@ export class ControlledGate {
 
       if (segment.type === 'vertical') {
         const height = segment.heightPixels ?? DEFAULT_VERTICAL_HEIGHT;
+        const xPosition = cursorX + segment.xOffset;
+        const worldX = this.originX + xPosition;
         const rect: GateRect = {
           type: 'V',
           index: i,
-          x: cursorX - GATE_THICKNESS / 2,
+          x: worldX - GATE_THICKNESS / 2,
           y: currentY - GATE_THICKNESS / 2,
           w: GATE_THICKNESS,
           h: height,
@@ -297,6 +299,7 @@ export class ControlledGate {
         };
         this.rects.push(rect);
         currentY += height;
+        cursorX = xPosition;
         continue;
       }
 

--- a/src/entities/enemies.ts
+++ b/src/entities/enemies.ts
@@ -179,13 +179,14 @@ class Enemy {
     }
   }
 
-  draw(ctx: CanvasRenderingContext2D, cameraYValue: number) {
+  draw(ctx: CanvasRenderingContext2D, cameraXValue: number, cameraYValue: number) {
     if (!this.active) return;
+    const screenX = this.x - cameraXValue;
     const screenY = this.y - cameraYValue;
     if (screenY < -50 || screenY > canvasHeight + 120) return;
 
     ctx.save();
-    ctx.translate(this.x, screenY);
+    ctx.translate(screenX, screenY);
 
     // While stunned, alternate between yellow and red instead of hiding
     ctx.fillStyle = this.stunned ? (this.stunVisible ? '#ffa94d' : '#ff4d4d') : '#ff4d4d';
@@ -322,8 +323,12 @@ export function updateEnemies(game: GameState, dt: number) {
   for (const enemy of enemies) enemy.update(dt, game);
 }
 
-export function drawEnemies(ctx: CanvasRenderingContext2D, cameraYValue: number) {
-  for (const enemy of enemies) enemy.draw(ctx, cameraYValue);
+export function drawEnemies(
+  ctx: CanvasRenderingContext2D,
+  cameraXValue: number,
+  cameraYValue: number
+) {
+  for (const enemy of enemies) enemy.draw(ctx, cameraXValue, cameraYValue);
 }
 
 export function pruneInactiveEnemies() {

--- a/src/entities/rides.ts
+++ b/src/entities/rides.ts
@@ -22,6 +22,7 @@ import {
 } from '../config/constants.js';
 import { clamp, rectsIntersect } from '../utils/utils.js';
 import { asciiArtEnabled } from '../systems/settings.js';
+import { canvasWidth as viewportWidth, cameraX } from '../core/globals.js';
 
 type LandingPhase = 'idle' | 'impact' | 'absorption' | 'recovery' | 'settle';
 type LaunchPhase = 'idle' | 'lift' | 'release' | 'settle';
@@ -103,8 +104,13 @@ export class Ride {
 
     this.x += this.speed * this.direction * dt;
 
-    if (this.direction > 0 && this.x > this.canvasWidth + this.width) this.active = false;
-    if (this.direction < 0 && this.x + this.width < 0) this.active = false;
+    if (this.direction !== 0) {
+      const margin = Math.max(120, this.width);
+      const viewLeft = cameraX - margin;
+      const viewRight = cameraX + viewportWidth + margin;
+      if (this.direction > 0 && this.x > viewRight) this.active = false;
+      if (this.direction < 0 && this.x + this.width < viewLeft) this.active = false;
+    }
   }
 
   startFloating() {

--- a/src/entities/rides.ts
+++ b/src/entities/rides.ts
@@ -114,7 +114,7 @@ export class Ride {
     this.direction = 0;
   }
 
-  draw(ctx, cameraY) {
+  draw(ctx, cameraX, cameraY) {
     if (!this.active) return;
 
     let color = this.originalSpeed >= RIDE_SPEED_THRESHOLD ? '#ff6b35' : '#4ecdc4';
@@ -127,10 +127,15 @@ export class Ride {
       ctx.textBaseline = 'middle';
       const count = Math.max(1, Math.floor(this.width / 8));
       const ascii = '='.repeat(count);
-      ctx.fillText(ascii, this.x, this.y - cameraY);
+      ctx.fillText(ascii, this.x - cameraX, this.y - cameraY);
     } else {
       ctx.fillStyle = color;
-      ctx.fillRect(this.x, this.y - RIDE_THICKNESS / 2 - cameraY, this.width, RIDE_THICKNESS);
+      ctx.fillRect(
+        this.x - cameraX,
+        this.y - RIDE_THICKNESS / 2 - cameraY,
+        this.width,
+        RIDE_THICKNESS
+      );
     }
   }
 
@@ -391,7 +396,21 @@ export class Ride {
   }
 }
 
-export function createRideFromInput({ distance, durationMs, screenY, cameraY, canvasWidth }) {
+export function createRideFromInput({
+  distance,
+  durationMs,
+  screenY,
+  cameraX,
+  cameraY,
+  canvasWidth,
+}: {
+  distance: number;
+  durationMs: number;
+  screenY: number;
+  cameraX: number;
+  cameraY: number;
+  canvasWidth: number;
+}) {
   const normalizedDuration = Math.max(1, durationMs);
   const direction = distance >= 0 ? 1 : -1;
   const distanceMagnitude = Math.abs(distance);
@@ -406,7 +425,7 @@ export function createRideFromInput({ distance, durationMs, screenY, cameraY, ca
   );
 
   const worldY = screenY + cameraY;
-  const startX = direction > 0 ? -width : canvasWidth;
+  const startX = direction > 0 ? cameraX - width : cameraX + canvasWidth;
 
   return new Ride({
     x: startX,
@@ -432,8 +451,8 @@ export function pruneInactiveRides(rides) {
   }
 }
 
-export function drawRides(ctx, rides, cameraY) {
-  for (const ride of rides) ride.draw(ctx, cameraY);
+export function drawRides(ctx, rides, cameraX, cameraY) {
+  for (const ride of rides) ride.draw(ctx, cameraX, cameraY);
 }
 
 export function mergeCollidingRides(rides, canvasWidth) {

--- a/src/entities/seamFloor.ts
+++ b/src/entities/seamFloor.ts
@@ -17,6 +17,7 @@ export class SeamFloor {
   epsilon: number;
   active = true;
   floating = false;
+  oneWay = true;
 
   constructor({ x, width, topY, thickness = GATE_THICKNESS, epsilon = 1 }: SeamFloorOptions) {
     this.baseX = x;

--- a/src/entities/seamFloor.ts
+++ b/src/entities/seamFloor.ts
@@ -1,0 +1,68 @@
+import { GATE_THICKNESS } from '../config/constants.js';
+import { asciiArtEnabled } from '../systems/settings.js';
+
+export interface SeamFloorOptions {
+  x: number;
+  width: number;
+  topY: number;
+  thickness?: number;
+  epsilon?: number;
+}
+
+export class SeamFloor {
+  baseX: number;
+  baseWidth: number;
+  y: number;
+  thickness: number;
+  epsilon: number;
+  active = true;
+  floating = false;
+
+  constructor({ x, width, topY, thickness = GATE_THICKNESS, epsilon = 1 }: SeamFloorOptions) {
+    this.baseX = x;
+    this.baseWidth = width;
+    this.thickness = thickness;
+    this.epsilon = epsilon;
+    this.y = topY - epsilon;
+  }
+
+  update(): void {}
+
+  getTopY(): number {
+    return this.y;
+  }
+
+  getRects() {
+    return [
+      {
+        x: this.baseX - this.epsilon,
+        y: this.y,
+        w: this.baseWidth + this.epsilon * 2,
+        h: this.thickness,
+      },
+    ];
+  }
+
+  draw(ctx: CanvasRenderingContext2D, cameraX: number, cameraY: number) {
+    if (!this.active) return;
+    const rect = this.getRects()[0];
+    const screenX = rect.x - cameraX;
+    const screenY = rect.y - cameraY;
+
+    if (asciiArtEnabled) {
+      ctx.fillStyle = '#8ab6ff';
+      const count = Math.max(1, Math.floor(rect.w / 12));
+      const ascii = '='.repeat(count);
+      ctx.textAlign = 'left';
+      ctx.textBaseline = 'middle';
+      ctx.font = '12px monospace';
+      ctx.fillText(ascii, screenX, screenY + rect.h / 2);
+    } else {
+      const gradient = ctx.createLinearGradient(screenX, screenY, screenX, screenY + rect.h);
+      gradient.addColorStop(0, 'rgba(120,180,255,0.8)');
+      gradient.addColorStop(1, 'rgba(120,180,255,0.3)');
+      ctx.fillStyle = gradient;
+      ctx.fillRect(screenX, screenY, rect.w, rect.h);
+    }
+  }
+}

--- a/src/entities/sprite.ts
+++ b/src/entities/sprite.ts
@@ -609,6 +609,7 @@ export class Sprite {
           const surfaceRight = rect.x + rect.w;
           const surfaceTop = rect.y;
           const surfaceBottom = rect.y + rect.h;
+          const isOneWaySurface = surface && surface.oneWay === true;
 
           const hOverlap = (currRight >= surfaceLeft) && (currLeft <= surfaceRight);
           const vOverlap = (currBottom >= surfaceTop) && (currTop <= surfaceBottom);
@@ -624,7 +625,7 @@ export class Sprite {
             }
           }
 
-          if (hOverlap && this.vy < 0 && prevTop >= surfaceBottom - epsilon && currTop <= surfaceBottom) {
+          if (!isOneWaySurface && hOverlap && this.vy < 0 && prevTop >= surfaceBottom - epsilon && currTop <= surfaceBottom) {
             if (!ceilingCandidate || surfaceBottom > ceilingCandidate.bottom) {
               ceilingCandidate = { surface, bottom: surfaceBottom };
             }

--- a/src/entities/sprite.ts
+++ b/src/entities/sprite.ts
@@ -14,7 +14,8 @@ import {
   RIDE_WEIGHT_SHIFT_MAX, GATE_THICKNESS
 } from '../config/constants.js';
 import { clamp } from '../utils/utils.js';
-import { canvasWidth, groundY, cameraY } from '../core/globals.js';
+import { canvasWidth, groundY, cameraY, cameraX } from '../core/globals.js';
+import { clampXToCard, getCurrentCard } from '../systems/cards.js';
 
 const SPRITE_SRC = '/icons/sprite.svg';
 const spriteImg = new window.Image();
@@ -561,7 +562,12 @@ export class Sprite {
 
     this.x += this.vx * dt;
     this.y += this.vy * dt;
-    this.x = clamp(this.x, hs, canvasWidth - hs);
+    const card = getCurrentCard();
+    if (card) {
+      this.x = clampXToCard(this.x, card, hs);
+    } else {
+      this.x = clamp(this.x, hs, canvasWidth - hs);
+    }
 
     const prevTop = prevY - hs;
     const prevBottom = prevY + hs;
@@ -752,8 +758,8 @@ export class Sprite {
     this._applyFinalScale();
   }
 
-  draw(ctx, cameraY) {
-    const px = this.x;
+  draw(ctx, cameraXValue, cameraYValue) {
+    const px = this.x - cameraXValue;
     let platformVisualYOffset = 0;
     if (this.onPlatform && this.platformSurface) {
       const surface = this.platformSurface;
@@ -763,7 +769,7 @@ export class Sprite {
         platformVisualYOffset = surface.y - surface.baseY;
       }
     }
-    const py = this.y - cameraY + platformVisualYOffset;
+    const py = this.y - cameraYValue + platformVisualYOffset;
     const size = SPRITE_SIZE;
 
     // --- Draw sprite (with mirroring and scaling) ---

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -6,6 +6,7 @@ export interface Rect {
 }
 
 export const clamp = (v: number, a: number, b: number): number => Math.max(a, Math.min(b, v));
+export const lerp = (a: number, b: number, t: number): number => a + (b - a) * t;
 export const now = (): number => performance.now();
 
 export function rectsIntersect(a: Rect, b: Rect): boolean {


### PR DESCRIPTION
## Summary
- compute per-card world rectangles, seam floors, and mapping helpers so the stack can span variable widths while preserving gate transitions
- add a SeamFloor surface entity and update gates/card plumbing to include it when stitching adjacent cards
- introduce horizontal camera tracking and update sprite, gates, rides, enemies, collectibles, and input handling to clamp and render against cameraX

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d38d652a64832d937731c6d5b61723