### PR TITLE
Render thin white gates when ASCII art is disabled

### DIFF
--- a/src/entities/controlledGate.ts
+++ b/src/entities/controlledGate.ts
@@ -446,9 +446,21 @@ export class ControlledGate {
         }
       }
     } else {
-      ctx.fillStyle = '#5aa2ff';
+      const visualThickness = Math.max(1, Math.round(GATE_THICKNESS / 5));
+      ctx.fillStyle = '#fff';
       for (const rect of rects) {
-        if (rect.w > 0 && rect.h > 0) ctx.fillRect(rect.x, rect.y - cameraY, rect.w, rect.h);
+        if (rect.w <= 0 || rect.h <= 0) continue;
+
+        const isHorizontal = rect.w >= rect.h;
+        if (isHorizontal) {
+          const height = Math.min(visualThickness, rect.h);
+          const offsetY = (rect.h - height) / 2;
+          ctx.fillRect(rect.x, rect.y - cameraY + offsetY, rect.w, height);
+        } else {
+          const width = Math.min(visualThickness, rect.w);
+          const offsetX = (rect.w - width) / 2;
+          ctx.fillRect(rect.x + offsetX, rect.y - cameraY, width, rect.h);
+        }
       }
 
       if (this.gapInfo) {

--- a/src/entities/controlledGate.ts
+++ b/src/entities/controlledGate.ts
@@ -4,6 +4,7 @@ import {
   GATE_GAP_WIDTH,
 } from '../config/constants.js';
 import { asciiArtEnabled } from '../systems/settings.js';
+import { drawGateVisuals } from './gateRenderer.js';
 
 const DEFAULT_VERTICAL_HEIGHT = 80; // Default height for auto-generated vertical connectors
 
@@ -425,55 +426,21 @@ export class ControlledGate {
     if (!this.active) return;
 
     const rects = this.getRects();
-    if (asciiArtEnabled) {
-      ctx.fillStyle = '#fff';
-      ctx.font = '16px monospace';
-      ctx.textAlign = 'center';
-      ctx.textBaseline = 'middle';
-      const horizontalGlyph = this.asciiDamaged ? '.' : ':';
-      const verticalGlyph = this.asciiDamaged ? ':' : '::';
-      for (const rect of rects) {
-        if (rect.w <= 0 || rect.h <= 0) continue;
-        if (rect.w > rect.h) {
-          const count = Math.max(1, Math.floor(rect.w / 10));
-          const ascii = horizontalGlyph.repeat(count);
-          ctx.fillText(ascii, rect.x + rect.w / 2, rect.y - cameraY + rect.h / 2);
-        } else {
-          const count = Math.max(1, Math.floor(rect.h / 16));
-          for (let i = 0; i < count; i++) {
-            ctx.fillText(verticalGlyph, rect.x + rect.w / 2, rect.y - cameraY + (i + 0.5) * (rect.h / count));
+    drawGateVisuals({
+      ctx,
+      rects,
+      cameraY,
+      asciiEnabled: asciiArtEnabled,
+      asciiDamaged: this.asciiDamaged,
+      gapInfo: this.gapInfo
+        ? {
+            type: this.gapInfo.type,
+            gapX: this.gapX,
+            gapY: this.gapY,
+            gapWidth: this.gapWidth,
           }
-        }
-      }
-    } else {
-      const visualThickness = Math.max(1, Math.round(GATE_THICKNESS / 5));
-      ctx.fillStyle = '#fff';
-      for (const rect of rects) {
-        if (rect.w <= 0 || rect.h <= 0) continue;
-
-        const isHorizontal = rect.w >= rect.h;
-        if (isHorizontal) {
-          const height = Math.min(visualThickness, rect.h);
-          const offsetY = (rect.h - height) / 2;
-          ctx.fillRect(rect.x, rect.y - cameraY + offsetY, rect.w, height);
-        } else {
-          const width = Math.min(visualThickness, rect.w);
-          const offsetX = (rect.w - width) / 2;
-          ctx.fillRect(rect.x + offsetX, rect.y - cameraY, width, rect.h);
-        }
-      }
-
-      if (this.gapInfo) {
-        ctx.fillStyle = 'rgba(255,255,255,0.15)';
-        if (this.gapInfo.type === 'H') {
-          ctx.fillRect(this.gapX, this.gapY - cameraY, 1, GATE_THICKNESS);
-          ctx.fillRect(this.gapX + this.gapWidth, this.gapY - cameraY, 1, GATE_THICKNESS);
-        } else {
-          ctx.fillRect(this.gapX, this.gapY - cameraY, GATE_THICKNESS, 1);
-          ctx.fillRect(this.gapX, this.gapY + this.gapWidth - cameraY, GATE_THICKNESS, 1);
-        }
-      }
-    }
+        : undefined,
+    });
   }
 }
 

--- a/src/entities/gateRenderer.ts
+++ b/src/entities/gateRenderer.ts
@@ -1,0 +1,96 @@
+import { GATE_THICKNESS } from '../config/constants.js';
+
+export interface GateVisualRect {
+  x: number;
+  y: number;
+  w: number;
+  h: number;
+}
+
+export interface GateVisualGapInfo {
+  type: 'H' | 'V';
+  gapX: number;
+  gapY: number;
+  gapWidth: number;
+}
+
+export interface DrawGateVisualsOptions {
+  ctx: CanvasRenderingContext2D;
+  rects: GateVisualRect[];
+  cameraY: number;
+  asciiEnabled: boolean;
+  asciiDamaged: boolean;
+  gapInfo?: GateVisualGapInfo | null;
+}
+
+export function drawGateVisuals({
+  ctx,
+  rects,
+  cameraY,
+  asciiEnabled,
+  asciiDamaged,
+  gapInfo,
+}: DrawGateVisualsOptions) {
+  if (asciiEnabled) {
+    ctx.fillStyle = '#fff';
+    ctx.font = '16px monospace';
+    ctx.textAlign = 'center';
+    ctx.textBaseline = 'middle';
+    const horizontalGlyph = asciiDamaged ? '.' : ':';
+    const verticalGlyph = asciiDamaged ? ':' : '::';
+
+    for (const rect of rects) {
+      if (rect.w <= 0 || rect.h <= 0) continue;
+
+      if (rect.w > rect.h) {
+        const count = Math.max(1, Math.floor(rect.w / 10));
+        const ascii = horizontalGlyph.repeat(count);
+        ctx.fillText(ascii, rect.x + rect.w / 2, rect.y - cameraY + rect.h / 2);
+      } else {
+        const count = Math.max(1, Math.floor(rect.h / 16));
+        for (let i = 0; i < count; i++) {
+          ctx.fillText(
+            verticalGlyph,
+            rect.x + rect.w / 2,
+            rect.y - cameraY + (i + 0.5) * (rect.h / count),
+          );
+        }
+      }
+    }
+    return;
+  }
+
+  const visualThickness = Math.max(1, Math.round(GATE_THICKNESS / 5));
+  ctx.fillStyle = '#fff';
+
+  for (const rect of rects) {
+    if (rect.w <= 0 || rect.h <= 0) continue;
+
+    const isHorizontal = rect.w >= rect.h;
+    if (isHorizontal) {
+      const height = Math.min(visualThickness, rect.h);
+      const offsetY = (rect.h - height) / 2;
+      ctx.fillRect(rect.x, rect.y - cameraY + offsetY, rect.w, height);
+    } else {
+      const width = Math.min(visualThickness, rect.w);
+      const offsetX = (rect.w - width) / 2;
+      ctx.fillRect(rect.x + offsetX, rect.y - cameraY, width, rect.h);
+    }
+  }
+
+  if (!gapInfo) return;
+
+  ctx.fillStyle = 'rgba(255,255,255,0.15)';
+  if (gapInfo.type === 'H') {
+    ctx.fillRect(gapInfo.gapX, gapInfo.gapY - cameraY, 1, GATE_THICKNESS);
+    ctx.fillRect(gapInfo.gapX + gapInfo.gapWidth, gapInfo.gapY - cameraY, 1, GATE_THICKNESS);
+  } else {
+    ctx.fillRect(gapInfo.gapX, gapInfo.gapY - cameraY, GATE_THICKNESS, 1);
+    ctx.fillRect(
+      gapInfo.gapX,
+      gapInfo.gapY + gapInfo.gapWidth - cameraY,
+      GATE_THICKNESS,
+      1,
+    );
+  }
+}

--- a/src/entities/gates.ts
+++ b/src/entities/gates.ts
@@ -13,6 +13,7 @@ import {
   type ControlledGateDefinition
 } from './controlledGate.js';
 import { asciiArtEnabled } from '../systems/settings.js';
+import { drawGateVisuals } from './gateRenderer.js';
 
 type GateRect = {
   type: 'H' | 'V';
@@ -201,56 +202,22 @@ export class Gate {
   draw(ctx: CanvasRenderingContext2D, cameraY: number) {
     if (!this.active) return;
 
-    if (asciiArtEnabled) {
-      ctx.fillStyle = '#fff';
-      ctx.font = '16px monospace';
-      ctx.textAlign = 'center';
-      ctx.textBaseline = 'middle';
-      const horizontalGlyph = this.asciiDamaged ? '.' : ':';
-      const verticalGlyph = this.asciiDamaged ? ':' : '::';
-      for (const rect of this.getRects()) {
-        if (rect.w > 0 && rect.h > 0) {
-          if (rect.w > rect.h) {
-            const count = Math.max(1, Math.floor(rect.w / 10));
-            const ascii = horizontalGlyph.repeat(count);
-            ctx.fillText(ascii, rect.x + rect.w / 2, rect.y - cameraY + rect.h / 2);
-          } else {
-            const count = Math.max(1, Math.floor(rect.h / 16));
-            for (let i = 0; i < count; i++) {
-              ctx.fillText(verticalGlyph, rect.x + rect.w / 2, rect.y - cameraY + (i + 0.5) * (rect.h / count));
-            }
+    const rects = this.getRects();
+    drawGateVisuals({
+      ctx,
+      rects,
+      cameraY,
+      asciiEnabled: asciiArtEnabled,
+      asciiDamaged: this.asciiDamaged,
+      gapInfo: this.gapInfo
+        ? {
+            type: this.gapInfo.type,
+            gapX: this.gapX,
+            gapY: this.gapY,
+            gapWidth: this.gapWidth,
           }
-        }
-      }
-    } else {
-      const visualThickness = Math.max(1, Math.round(GATE_THICKNESS / 5));
-      ctx.fillStyle = '#fff';
-      for (const rect of this.getRects()) {
-        if (rect.w <= 0 || rect.h <= 0) continue;
-
-        const isHorizontal = rect.w >= rect.h;
-        if (isHorizontal) {
-          const height = Math.min(visualThickness, rect.h);
-          const offsetY = (rect.h - height) / 2;
-          ctx.fillRect(rect.x, rect.y - cameraY + offsetY, rect.w, height);
-        } else {
-          const width = Math.min(visualThickness, rect.w);
-          const offsetX = (rect.w - width) / 2;
-          ctx.fillRect(rect.x + offsetX, rect.y - cameraY, width, rect.h);
-        }
-      }
-
-      ctx.fillStyle = 'rgba(255,255,255,0.15)';
-      if (this.gapInfo?.type === 'H') {
-        const gapY = this.gapY;
-        ctx.fillRect(this.gapX, gapY - cameraY, 1, GATE_THICKNESS);
-        ctx.fillRect(this.gapX + this.gapWidth, gapY - cameraY, 1, GATE_THICKNESS);
-      } else if (this.gapInfo?.type === 'V') {
-        const gapX = this.gapX;
-        ctx.fillRect(gapX, this.gapY - cameraY, GATE_THICKNESS, 1);
-        ctx.fillRect(gapX, this.gapY + this.gapWidth - cameraY, GATE_THICKNESS, 1);
-      }
-    }
+        : undefined,
+    });
   }
 }
 

--- a/src/entities/gates.ts
+++ b/src/entities/gates.ts
@@ -223,9 +223,21 @@ export class Gate {
         }
       }
     } else {
-      ctx.fillStyle = '#5aa2ff';
+      const visualThickness = Math.max(1, Math.round(GATE_THICKNESS / 5));
+      ctx.fillStyle = '#fff';
       for (const rect of this.getRects()) {
-        if (rect.w > 0 && rect.h > 0) ctx.fillRect(rect.x, rect.y - cameraY, rect.w, rect.h);
+        if (rect.w <= 0 || rect.h <= 0) continue;
+
+        const isHorizontal = rect.w >= rect.h;
+        if (isHorizontal) {
+          const height = Math.min(visualThickness, rect.h);
+          const offsetY = (rect.h - height) / 2;
+          ctx.fillRect(rect.x, rect.y - cameraY + offsetY, rect.w, height);
+        } else {
+          const width = Math.min(visualThickness, rect.w);
+          const offsetX = (rect.w - width) / 2;
+          ctx.fillRect(rect.x + offsetX, rect.y - cameraY, width, rect.h);
+        }
       }
 
       ctx.fillStyle = 'rgba(255,255,255,0.15)';

--- a/src/entities/rides.ts
+++ b/src/entities/rides.ts
@@ -129,8 +129,10 @@ export class Ride {
       const ascii = '='.repeat(count);
       ctx.fillText(ascii, this.x, this.y - cameraY);
     } else {
+      const visualThickness = Math.max(1, Math.round(RIDE_THICKNESS / 5));
+      const offsetY = this.y - cameraY - visualThickness / 2;
       ctx.fillStyle = color;
-      ctx.fillRect(this.x, this.y - RIDE_THICKNESS / 2 - cameraY, this.width, RIDE_THICKNESS);
+      ctx.fillRect(this.x, offsetY, this.width, visualThickness);
     }
   }
 


### PR DESCRIPTION
## Summary
- render gates with thin white rectangles when ASCII art is disabled to better match the ASCII styling

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e5fbc0a4f8832d8d0381654b244b84