### PR TITLE
Add animated starfield background

### DIFF
--- a/src/core/globals.ts
+++ b/src/core/globals.ts
@@ -79,15 +79,6 @@ export const game: GameState = {
 
 // Background grid drawing (used in main draw)
 export function drawBackgroundGrid() {
-  ctx.save();
-
-  const gradient = ctx.createLinearGradient(0, 0, 0, canvasHeight);
-  gradient.addColorStop(0, 'rgba(18, 16, 46, 0.45)');
-  gradient.addColorStop(0.55, 'rgba(7, 7, 17, 0.15)');
-  gradient.addColorStop(1, 'rgba(0, 0, 0, 0)');
-
-  ctx.fillStyle = gradient;
-  ctx.fillRect(0, 0, canvasWidth, canvasHeight);
-
-  ctx.restore();
+  // Intentionally left blank so the animated starfield background can show
+  // through the transparent gameplay canvas.
 }

--- a/src/core/globals.ts
+++ b/src/core/globals.ts
@@ -1,4 +1,4 @@
-import { GRID_SIZE, CANVAS_MAX_WIDTH } from '../config/constants.js';
+import { CANVAS_MAX_WIDTH } from '../config/constants.js';
 
 type Sprite = import('../entities/sprite.js').Sprite;
 type Ride = import('../entities/rides.js').Ride;
@@ -81,22 +81,13 @@ export const game: GameState = {
 export function drawBackgroundGrid() {
   ctx.save();
 
-  ctx.fillStyle = 'rgba(255,255,255,0.08)'; // slightly brighter than 0.04 so dots are visible
+  const gradient = ctx.createLinearGradient(0, 0, 0, canvasHeight);
+  gradient.addColorStop(0, 'rgba(18, 16, 46, 0.45)');
+  gradient.addColorStop(0.55, 'rgba(7, 7, 17, 0.15)');
+  gradient.addColorStop(1, 'rgba(0, 0, 0, 0)');
 
-  const worldTop = cameraY;
-  const worldBottom = cameraY + canvasHeight;
-
-  let firstY = Math.floor(worldTop / GRID_SIZE) * GRID_SIZE;
-  if (firstY > worldTop) firstY -= GRID_SIZE;
-
-  for (let y = firstY; y <= worldBottom; y += GRID_SIZE) {
-    const sy = y - cameraY;
-    for (let x = 0; x <= canvasWidth; x += GRID_SIZE) {
-      ctx.beginPath();
-      ctx.arc(x, sy, 1.2, 0, Math.PI * 2); // radius ~1–2px looks nice
-      ctx.fill();
-    }
-  }
+  ctx.fillStyle = gradient;
+  ctx.fillRect(0, 0, canvasWidth, canvasHeight);
 
   ctx.restore();
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -2,7 +2,7 @@
 import './styles/styles.css';
 
 // Starfield background
-import './ui/starfield.js';
+import './ui/starfield';
 
 // Import and start the game
 import './core/game.js';

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,6 +1,9 @@
 // Import styles
 import './styles/styles.css';
 
+// Starfield background
+import './ui/starfield.js';
+
 // Import and start the game
 import './core/game.js';
 

--- a/src/styles/styles.css
+++ b/src/styles/styles.css
@@ -7,13 +7,20 @@ html, body {
   color: var(--ink);
   font: 14px/1.2 "Courier New", ui-monospace, monospace;
 }
+#starfieldCanvas {
+  position: fixed;
+  inset: 0;
+  z-index: -1;
+  display: block;
+  pointer-events: none;
+}
 #wrap {
   max-width: 960px;
   margin: 0 auto;
   padding: 12px;
   text-align: center;
 }
-canvas {
+#gameCanvas {
   display: block;
   width: 100%;
   max-width: 480px;

--- a/src/styles/styles.css
+++ b/src/styles/styles.css
@@ -3,14 +3,14 @@
 html, body {
   height: 100%;
   margin: 0;
-  background: var(--bg);
+  background: #000;
   color: var(--ink);
   font: 14px/1.2 "Courier New", ui-monospace, monospace;
 }
 #starfieldCanvas {
   position: fixed;
   inset: 0;
-  z-index: -1;
+  z-index: 0;
   display: block;
   pointer-events: none;
 }
@@ -26,7 +26,9 @@ html, body {
   max-width: 480px;
   margin: 0 auto;
   height: auto;
-  background-color: var(--bg);
+  position: relative;
+  z-index: 1;
+  background-color: transparent;
   /* background-image:
     radial-gradient(1200px 600px at 20% -10%, rgba(255,255,255,.035), transparent 65%),
     radial-gradient(800px 400px at 80% 10%, rgba(255,255,255,.025), transparent 60%),

--- a/src/systems/settings.ts
+++ b/src/systems/settings.ts
@@ -49,6 +49,7 @@ export function drawSettings() {
   overlay.style.display = 'flex';
   overlay.style.alignItems = 'center';
   overlay.style.justifyContent = 'center';
+  overlay.style.zIndex = '5';
 
   const panel = document.createElement('div');
   panel.style.background = '#000';

--- a/src/ui/starfield.ts
+++ b/src/ui/starfield.ts
@@ -1,0 +1,180 @@
+const STARFIELD_CANVAS_ID = 'starfieldCanvas';
+
+interface Star {
+  x: number;
+  y: number;
+  type: 'small' | 'bright';
+  baseAlpha: number;
+  twinkleSpeed: number;
+  offset: number;
+  currentAlpha?: number;
+}
+
+const baseConfig = {
+  numSmallStars: 100,
+  numBrightStars: 20,
+  baseWidth: 1024,
+  baseHeight: 768
+};
+
+let canvas: HTMLCanvasElement | null = null;
+let ctx: CanvasRenderingContext2D | null = null;
+let stars: Star[] = [];
+let lastTime = 0;
+
+function ensureCanvas(): void {
+  if (canvas) return;
+
+  const existing = document.getElementById(STARFIELD_CANVAS_ID) as HTMLCanvasElement | null;
+  if (existing) {
+    canvas = existing;
+  } else {
+    canvas = document.createElement('canvas');
+    canvas.id = STARFIELD_CANVAS_ID;
+    canvas.setAttribute('aria-hidden', 'true');
+    document.body.prepend(canvas);
+  }
+
+  ctx = canvas.getContext('2d', { alpha: false });
+}
+
+function resizeCanvas(): void {
+  if (!canvas) return;
+
+  const dpr = window.devicePixelRatio || 1;
+  const width = window.innerWidth;
+  const height = window.innerHeight;
+
+  canvas.width = Math.round(width * dpr);
+  canvas.height = Math.round(height * dpr);
+  canvas.style.width = `${width}px`;
+  canvas.style.height = `${height}px`;
+
+  if (ctx) {
+    ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+  }
+}
+
+function getCanvasDimensions(): { width: number; height: number } {
+  if (!canvas) {
+    return { width: baseConfig.baseWidth, height: baseConfig.baseHeight };
+  }
+
+  return {
+    width: canvas.clientWidth || baseConfig.baseWidth,
+    height: canvas.clientHeight || baseConfig.baseHeight
+  };
+}
+
+function computeStarCounts(): { small: number; bright: number } {
+  const { width, height } = getCanvasDimensions();
+  const area = Math.max(width * height, 1);
+  const baseArea = baseConfig.baseWidth * baseConfig.baseHeight;
+  const ratio = area / baseArea;
+
+  const small = Math.max(40, Math.round(baseConfig.numSmallStars * ratio));
+  const bright = Math.max(8, Math.round(baseConfig.numBrightStars * ratio));
+
+  return { small, bright };
+}
+
+function initStars(): void {
+  stars = [];
+  const { small, bright } = computeStarCounts();
+  const { width, height } = getCanvasDimensions();
+
+  for (let i = 0; i < small; i += 1) {
+    stars.push({
+      x: Math.random() * width,
+      y: Math.random() * height,
+      type: 'small',
+      baseAlpha: 0.5 + Math.random() * 0.5,
+      twinkleSpeed: 1 + Math.random() * 2,
+      offset: Math.random() * Math.PI * 2
+    });
+  }
+
+  for (let i = 0; i < bright; i += 1) {
+    stars.push({
+      x: Math.random() * width,
+      y: Math.random() * height,
+      type: 'bright',
+      baseAlpha: 0.7 + Math.random() * 0.3,
+      twinkleSpeed: 0.5 + Math.random(),
+      offset: Math.random() * Math.PI * 2
+    });
+  }
+}
+
+function update(dt: number): void {
+  for (const star of stars) {
+    star.offset += dt * star.twinkleSpeed;
+    const alpha = star.baseAlpha + Math.sin(star.offset) * 0.3;
+    star.currentAlpha = Math.max(0.3, Math.min(1, alpha));
+  }
+}
+
+function draw(): void {
+  if (!ctx || !canvas) return;
+
+  const { width, height } = getCanvasDimensions();
+
+  ctx.fillStyle = '#000';
+  ctx.fillRect(0, 0, width, height);
+
+  for (const star of stars) {
+    const alpha = star.currentAlpha ?? star.baseAlpha;
+
+    ctx.globalAlpha = alpha;
+    ctx.fillStyle = '#fff';
+    ctx.strokeStyle = '#fff';
+
+    if (star.type === 'small') {
+      ctx.fillRect(Math.floor(star.x), Math.floor(star.y), 2, 2);
+    } else {
+      const x = Math.floor(star.x);
+      const y = Math.floor(star.y);
+      ctx.fillRect(x - 2, y, 5, 1);
+      ctx.fillRect(x, y - 2, 1, 5);
+    }
+  }
+
+  ctx.globalAlpha = 1;
+}
+
+function animate(currentTime: number): void {
+  if (!canvas) return;
+
+  const dt = (currentTime - lastTime) / 1000;
+  lastTime = currentTime;
+
+  if (dt < 0.1) {
+    update(dt);
+    draw();
+  }
+
+  window.requestAnimationFrame(animate);
+}
+
+function handleResize(): void {
+  resizeCanvas();
+  initStars();
+}
+
+function setupStarfield(): void {
+  ensureCanvas();
+  resizeCanvas();
+  initStars();
+  lastTime = performance.now();
+  window.requestAnimationFrame(animate);
+  window.removeEventListener('resize', handleResize);
+  window.addEventListener('resize', handleResize);
+}
+
+if (typeof window !== 'undefined') {
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', setupStarfield, { once: true });
+  } else {
+    setupStarfield();
+  }
+}


### PR DESCRIPTION
## Summary
- add a dedicated starfield canvas that renders a twinkling night sky behind the game
- scope existing canvas styles to the gameplay surface and position the starfield canvas behind it
- load the new starfield module from the app entrypoint so the animation initializes automatically

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e6043cde08832d8b871fb38b29cd1b