### PR TITLE
Remove ASCII rendering mode

### DIFF
--- a/src/entities/controlledGate.ts
+++ b/src/entities/controlledGate.ts
@@ -3,7 +3,6 @@ import {
   PIXELS_PER_FOOT,
   GATE_GAP_WIDTH,
 } from '../config/constants.js';
-import { asciiArtEnabled } from '../systems/settings.js';
 import { drawGateVisuals } from './gateRenderer.js';
 
 const DEFAULT_VERTICAL_HEIGHT = 80; // Default height for auto-generated vertical connectors
@@ -94,7 +93,6 @@ export class ControlledGate {
   direction = 0;
   originalSpeed = 0;
   rewardEnabled = true;
-  asciiDamaged = false;
   segments: Segment[] = [];
   rects: GateRect[] = [];
   gapInfo?: GapInfo;
@@ -116,9 +114,6 @@ export class ControlledGate {
   startFloating(): void {}
 
   handleBottomCollision(): void {
-    if (!this.asciiDamaged) {
-      this.asciiDamaged = true;
-    }
     this.rewardEnabled = false;
   }
 
@@ -430,8 +425,6 @@ export class ControlledGate {
       ctx,
       rects,
       cameraY,
-      asciiEnabled: asciiArtEnabled,
-      asciiDamaged: this.asciiDamaged,
       gapInfo: this.gapInfo
         ? {
             type: this.gapInfo.type,

--- a/src/entities/gateRenderer.ts
+++ b/src/entities/gateRenderer.ts
@@ -18,8 +18,6 @@ export interface DrawGateVisualsOptions {
   ctx: CanvasRenderingContext2D;
   rects: GateVisualRect[];
   cameraY: number;
-  asciiEnabled: boolean;
-  asciiDamaged: boolean;
   gapInfo?: GateVisualGapInfo | null;
 }
 
@@ -27,39 +25,8 @@ export function drawGateVisuals({
   ctx,
   rects,
   cameraY,
-  asciiEnabled,
-  asciiDamaged,
   gapInfo,
 }: DrawGateVisualsOptions) {
-  if (asciiEnabled) {
-    ctx.fillStyle = '#fff';
-    ctx.font = '16px monospace';
-    ctx.textAlign = 'center';
-    ctx.textBaseline = 'middle';
-    const horizontalGlyph = asciiDamaged ? '.' : ':';
-    const verticalGlyph = asciiDamaged ? ':' : '::';
-
-    for (const rect of rects) {
-      if (rect.w <= 0 || rect.h <= 0) continue;
-
-      if (rect.w > rect.h) {
-        const count = Math.max(1, Math.floor(rect.w / 10));
-        const ascii = horizontalGlyph.repeat(count);
-        ctx.fillText(ascii, rect.x + rect.w / 2, rect.y - cameraY + rect.h / 2);
-      } else {
-        const count = Math.max(1, Math.floor(rect.h / 16));
-        for (let i = 0; i < count; i++) {
-          ctx.fillText(
-            verticalGlyph,
-            rect.x + rect.w / 2,
-            rect.y - cameraY + (i + 0.5) * (rect.h / count),
-          );
-        }
-      }
-    }
-    return;
-  }
-
   const visualThickness = Math.max(1, Math.round(GATE_THICKNESS / 5));
   ctx.fillStyle = '#fff';
 

--- a/src/entities/gates.ts
+++ b/src/entities/gates.ts
@@ -12,7 +12,6 @@ import {
   ControlledGate,
   type ControlledGateDefinition
 } from './controlledGate.js';
-import { asciiArtEnabled } from '../systems/settings.js';
 import { drawGateVisuals } from './gateRenderer.js';
 
 type GateRect = {
@@ -37,7 +36,6 @@ export class Gate {
   direction: number;
   originalSpeed: number;
   rewardEnabled: boolean;
-  asciiDamaged: boolean;
   horizontalSegments: number[];
   verticalOffsets: number[];
   rects: GateRect[];
@@ -62,7 +60,6 @@ export class Gate {
     this.direction = 0;
     this.originalSpeed = 0;
     this.rewardEnabled = true;
-    this.asciiDamaged = false;
 
     this._generateLayout();
     this._chooseGap();
@@ -73,9 +70,6 @@ export class Gate {
   startFloating() {}
 
   handleBottomCollision() {
-    if (!this.asciiDamaged) {
-      this.asciiDamaged = true;
-    }
     this.rewardEnabled = false;
   }
 
@@ -207,8 +201,6 @@ export class Gate {
       ctx,
       rects,
       cameraY,
-      asciiEnabled: asciiArtEnabled,
-      asciiDamaged: this.asciiDamaged,
       gapInfo: this.gapInfo
         ? {
             type: this.gapInfo.type,

--- a/src/entities/rides.ts
+++ b/src/entities/rides.ts
@@ -21,7 +21,6 @@ import {
   RIDE_LAUNCH_VELOCITY_FACTOR,
 } from '../config/constants.js';
 import { clamp, rectsIntersect } from '../utils/utils.js';
-import { asciiArtEnabled } from '../systems/settings.js';
 
 type LandingPhase = 'idle' | 'impact' | 'absorption' | 'recovery' | 'settle';
 type LaunchPhase = 'idle' | 'lift' | 'release' | 'settle';
@@ -120,20 +119,10 @@ export class Ride {
     let color = this.originalSpeed >= RIDE_SPEED_THRESHOLD ? '#ff6b35' : '#4ecdc4';
     if (this.floating) color = '#9b59b6';
 
-    if (asciiArtEnabled) {
-      ctx.fillStyle = color;
-      ctx.font = '16px monospace';
-      ctx.textAlign = 'left';
-      ctx.textBaseline = 'middle';
-      const count = Math.max(1, Math.floor(this.width / 8));
-      const ascii = '='.repeat(count);
-      ctx.fillText(ascii, this.x, this.y - cameraY);
-    } else {
-      const visualThickness = Math.max(1, Math.round(RIDE_THICKNESS / 5));
-      const offsetY = this.y - cameraY - visualThickness / 2;
-      ctx.fillStyle = color;
-      ctx.fillRect(this.x, offsetY, this.width, visualThickness);
-    }
+    const visualThickness = Math.max(1, Math.round(RIDE_THICKNESS / 5));
+    const offsetY = this.y - cameraY - visualThickness / 2;
+    ctx.fillStyle = color;
+    ctx.fillRect(this.x, offsetY, this.width, visualThickness);
   }
 
   getRect() {

--- a/src/systems/settings.ts
+++ b/src/systems/settings.ts
@@ -5,10 +5,6 @@ export let showSettings = false;
 export function toggleSettings() { showSettings = !showSettings; }
 export function hideSettings() { showSettings = false; }
 
-// ASCII art rendering setting (default: on)
-export let asciiArtEnabled = true;
-export function setAsciiArtEnabled(v) { asciiArtEnabled = !!v; }
-
 let overlay = null;
 
 export function drawSettingsIcon(ctx) {
@@ -87,42 +83,6 @@ export function drawSettings() {
   list.style.flexDirection = 'column';
   list.style.gap = '12px';
   list.style.margin = '8px 0 12px 0';
-
-  // ASCII Art toggle row
-  const asciiRow = document.createElement('div');
-  asciiRow.style.display = 'flex';
-  asciiRow.style.alignItems = 'center';
-  asciiRow.style.justifyContent = 'space-between';
-  asciiRow.style.border = '1px solid #fff';
-  asciiRow.style.padding = '10px 12px';
-  asciiRow.style.background = 'rgba(255,255,255,0.05)';
-
-  const asciiLabel = document.createElement('div');
-  asciiLabel.textContent = 'ASCII ART';
-  asciiLabel.style.fontSize = '12px';
-
-  const asciiToggle = document.createElement('button');
-  asciiToggle.style.fontFamily = 'LocalPressStart, monospace';
-  asciiToggle.style.fontSize = '12px';
-  asciiToggle.style.color = '#fff';
-  asciiToggle.style.background = 'transparent';
-  asciiToggle.style.border = '2px solid #fff';
-  asciiToggle.style.padding = '6px 10px';
-  asciiToggle.style.cursor = 'pointer';
-  asciiToggle.style.boxShadow = 'none';
-  function updateAsciiButton() {
-    asciiToggle.textContent = asciiArtEnabled ? 'ON' : 'OFF';
-    asciiToggle.style.opacity = asciiArtEnabled ? '1' : '0.7';
-  }
-  updateAsciiButton();
-  asciiToggle.addEventListener('click', () => {
-    setAsciiArtEnabled(!asciiArtEnabled);
-    updateAsciiButton();
-  });
-  asciiRow.appendChild(asciiLabel);
-  asciiRow.appendChild(asciiToggle);
-
-  list.appendChild(asciiRow);
 
   // Budget editor
   const budgetLabel = document.createElement('div');


### PR DESCRIPTION
## Summary
- remove ASCII art parameters from gate rendering and drop the damage state used only for ASCII output
- simplify ride rendering to always draw the solid hoverboard bar
- remove the ASCII art toggle from the settings overlay now that only the solid visuals remain

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e60f8165dc832d859facb6235ce264