### PR TITLE
Switch damaged gates to yellow when ASCII mode is off

### DIFF
--- a/src/entities/gateRenderer.ts
+++ b/src/entities/gateRenderer.ts
@@ -61,7 +61,10 @@ export function drawGateVisuals({
   }
 
   const visualThickness = Math.max(1, Math.round(GATE_THICKNESS / 5));
-  ctx.fillStyle = '#fff';
+  const defaultColor = '#fff';
+  const damagedColor = '#ffd400';
+  const gateColor = !asciiEnabled && asciiDamaged ? damagedColor : defaultColor;
+  ctx.fillStyle = gateColor;
 
   for (const rect of rects) {
     if (rect.w <= 0 || rect.h <= 0) continue;
@@ -80,7 +83,10 @@ export function drawGateVisuals({
 
   if (!gapInfo) return;
 
-  ctx.fillStyle = 'rgba(255,255,255,0.15)';
+  const gapHighlightColor = !asciiEnabled && asciiDamaged
+    ? 'rgba(255,212,0,0.25)'
+    : 'rgba(255,255,255,0.15)';
+  ctx.fillStyle = gapHighlightColor;
   if (gapInfo.type === 'H') {
     ctx.fillRect(gapInfo.gapX, gapInfo.gapY - cameraY, 1, GATE_THICKNESS);
     ctx.fillRect(gapInfo.gapX + gapInfo.gapWidth, gapInfo.gapY - cameraY, 1, GATE_THICKNESS);


### PR DESCRIPTION
## Summary
- update gate rendering to swap to a yellow color when damaged with ASCII mode disabled
- tint the gap highlight to match the new damaged color

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e61dfaab84832dbe1444ef3dc16a33