### PR TITLE
Adjust bubble density and energy-based swim speed

### DIFF
--- a/src/defold/game_objects/sprite.ts
+++ b/src/defold/game_objects/sprite.ts
@@ -250,14 +250,17 @@ export class Sprite {
       } else {
         // Normal movement
         const r = Math.min(1, this.movementChargeTime / CHARGE_TIME);
-        let force = MOVEMENT_MIN + (MOVEMENT_MAX - MOVEMENT_MIN) * r;
+        let normalized = r;
         const energyBar = this.hooks.energyBar;
         if (energyBar && typeof energyBar.energy === 'number' && ENERGY_MAX > 0) {
           const energyRatio = clamp(energyBar.energy / ENERGY_MAX, 0, 1);
           const depletion = 1 - energyRatio;
-          const depletionBoost = 1 + depletion * 0.6;
-          force *= depletionBoost;
+          // More depleted energy should translate into a sharper dart even on light swipes.
+          // Blend the current charge with the depletion so low charge + low energy still yields
+          // a high normalized stroke value.
+          normalized = clamp(r + depletion * (1 - r), 0, 1);
         }
+        let force = MOVEMENT_MIN + (MOVEMENT_MAX - MOVEMENT_MIN) * normalized;
         if (this.inWater && !this.onGround) {
           force *= WATER_STROKE_FORCE_SCALE;
         }

--- a/src/defold/game_objects/sprite.ts
+++ b/src/defold/game_objects/sprite.ts
@@ -16,6 +16,7 @@ import {
   WATER_MAX_SPEED, WATER_STROKE_FORCE_SCALE, WATER_ENTRY_DAMPING,
   WATER_MAX_SINK_SPEED, WATER_PIXELS_PER_METER, WATER_SURFACE_TOLERANCE,
   ENERGY_REGEN_STATIONARY_DELAY,
+  ENERGY_MAX,
   OXYGEN_MAX, OXYGEN_DEPLETION_RATE, OXYGEN_RECHARGE_RATE,
   OXYGEN_DAMAGE_INTERVAL,
   BUBBLE_SHRINK_RATE_PER_SECOND,
@@ -250,6 +251,13 @@ export class Sprite {
         // Normal movement
         const r = Math.min(1, this.movementChargeTime / CHARGE_TIME);
         let force = MOVEMENT_MIN + (MOVEMENT_MAX - MOVEMENT_MIN) * r;
+        const energyBar = this.hooks.energyBar;
+        if (energyBar && typeof energyBar.energy === 'number' && ENERGY_MAX > 0) {
+          const energyRatio = clamp(energyBar.energy / ENERGY_MAX, 0, 1);
+          const depletion = 1 - energyRatio;
+          const depletionBoost = 1 + depletion * 0.6;
+          force *= depletionBoost;
+        }
         if (this.inWater && !this.onGround) {
           force *= WATER_STROKE_FORCE_SCALE;
         }

--- a/src/defold/runtime/environment/bubble_field.ts
+++ b/src/defold/runtime/environment/bubble_field.ts
@@ -57,8 +57,8 @@ export interface BubbleEnvironment {
   wellBounds: WellBounds;
 }
 
-const STATIC_SEGMENT_HEIGHT = 100;
-const STATIC_BUBBLES_PER_SEGMENT = 5;
+const STATIC_SEGMENT_HEIGHT = 120;
+const STATIC_BUBBLES_PER_SEGMENT = 3;
 const STATIC_PIXEL_SIZE = 4;
 
 const MIN_SMALL_BUBBLE_RADIUS = 10;


### PR DESCRIPTION
## Summary
- reduce the density of static background bubbles for a calmer backdrop
- scale swimming thrust based on the current energy level so depleted power yields faster darts

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68f403bb2a04832da578b88061eb5703